### PR TITLE
fix: reduce review noise — changed-lines-only + group similar findings

### DIFF
--- a/src/vigil/github_review.py
+++ b/src/vigil/github_review.py
@@ -1,13 +1,15 @@
 """Post review results as GitHub PR review comments with inline annotations."""
 
+import difflib
 import logging
+from collections import defaultdict
 
 import httpx
 
 from .comment_manager import deduplicate_comments
 from .diff_parser import commentable_lines, find_best_file_for_finding, nearest_commentable_line
 from .models import Finding, PersonaVerdict, ReviewResult, Severity
-from .utils import github_headers, severity_emoji
+from .utils import extract_message_content, github_headers, severity_emoji
 
 log = logging.getLogger(__name__)
 
@@ -192,6 +194,88 @@ def _place_finding_inline(
     return {"path": path, "line": line, "side": "RIGHT", "body": body}
 
 
+def _group_similar_inline_comments(
+    comments: list[dict],
+    similarity_threshold: float = 0.85,
+) -> list[dict]:
+    """Group inline comments with near-identical messages across different locations.
+
+    When the same finding (e.g. "redundant db.commit()") appears at N locations,
+    post ONE representative comment and append a summary of the other locations.
+    This prevents review spam where 20+ identical comments flood the PR.
+
+    Returns a deduplicated list of inline comment dicts.
+    """
+    if len(comments) <= 1:
+        return list(comments)
+
+    # Extract normalized message text for each comment
+    texts = [extract_message_content(c.get("body", "")) for c in comments]
+
+    # Group by message similarity — union-find style
+    # group_id[i] = canonical index for comment i
+    group_id = list(range(len(comments)))
+
+    def find(i: int) -> int:
+        while group_id[i] != i:
+            group_id[i] = group_id[group_id[i]]
+            i = group_id[i]
+        return i
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            group_id[rb] = ra
+
+    for i in range(len(comments)):
+        if not texts[i]:
+            continue
+        for j in range(i + 1, len(comments)):
+            if not texts[j]:
+                continue
+            # Skip if already in same group
+            if find(i) == find(j):
+                continue
+            ratio = difflib.SequenceMatcher(None, texts[i], texts[j]).ratio()
+            if ratio >= similarity_threshold:
+                union(i, j)
+
+    # Collect groups
+    groups: dict[int, list[int]] = defaultdict(list)
+    for i in range(len(comments)):
+        groups[find(i)].append(i)
+
+    result: list[dict] = []
+    for members in groups.values():
+        if len(members) == 1:
+            result.append(comments[members[0]])
+            continue
+
+        # Pick the representative (first comment in the group)
+        rep_idx = members[0]
+        rep = dict(comments[rep_idx])  # shallow copy
+        others = members[1:]
+
+        # Build "also found at" summary
+        locations = []
+        for idx in others:
+            c = comments[idx]
+            locations.append(f"`{c['path']}:{c['line']}`")
+
+        also_note = (
+            f"\n\n---\n🔁 **Same pattern in {len(others)} other location{'s' if len(others) != 1 else ''}:** "
+            + ", ".join(locations)
+        )
+        rep["body"] = rep["body"] + also_note
+        result.append(rep)
+        log.info(
+            "Grouped %d similar findings into 1 comment (%s:%s)",
+            len(members), rep["path"], rep["line"],
+        )
+
+    return result
+
+
 def post_review(
     owner: str,
     repo: str,
@@ -255,6 +339,13 @@ def post_review(
         dupes = before_count - len(inline_comments)
         if dupes:
             log.info("Deduplicated %d comments (already posted)", dupes)
+
+    # Group similar findings within this review to avoid spam
+    before_group = len(inline_comments)
+    inline_comments = _group_similar_inline_comments(inline_comments)
+    grouped = before_group - len(inline_comments)
+    if grouped:
+        log.info("Grouped %d similar comments into representative comments", grouped)
 
     # Build the body
     body = _build_review_body(result, inline_count=len(inline_comments), observation_issues=observation_issues)

--- a/src/vigil/personas.py
+++ b/src/vigil/personas.py
@@ -31,6 +31,13 @@ Rules:
 - Only return REQUEST_CHANGES if there are high or critical severity findings.
 - Be specific: file paths, line numbers, concrete suggestions.
 
+CHANGED LINES ONLY — THIS IS CRITICAL:
+- You are reviewing a DIFF. Only flag issues on lines that were ADDED or MODIFIED
+  (lines starting with + in the diff). These are the lines the author wrote in this PR.
+- Do NOT flag issues on context lines (unchanged lines shown for surrounding context).
+  Those lines existed before this PR and are not the author's responsibility here.
+- If unchanged code has a problem, it is OUT OF SCOPE for THIS review.
+
 SIGNAL-TO-NOISE — THIS IS CRITICAL:
 - Your job is to catch REAL problems, not to prove you read the code.
 - If this domain looks clean, return APPROVE with EMPTY findings and observations.


### PR DESCRIPTION
## Summary
- **VERDICT_SCHEMA** now instructs all specialists to only flag issues on `+` lines (added/modified in the diff), not context lines that existed before the PR
- **Within-review grouping**: findings with ≥85% message similarity are collapsed into 1 representative inline comment that lists all other locations — prevents the "24 identical `redundant db.commit()` comments" problem
- All 271 existing tests pass

## Motivation
PR #243 on bioqms-core triggered 24 nearly identical "redundant db.commit()" comments from Vigil. Root causes:
1. Specialists were commenting on unchanged context lines in the diff
2. No within-review deduplication — each identical finding got its own inline comment

## Changes
| File | Change |
|------|--------|
| `src/vigil/personas.py` | Added "CHANGED LINES ONLY" instruction to VERDICT_SCHEMA |
| `src/vigil/github_review.py` | Added `_group_similar_inline_comments()` with union-find grouping, called before body build |

## Test plan
- [x] All 271 existing tests pass
- [ ] Trigger a review on a PR with repeated patterns (e.g. same issue in multiple files) and verify grouping
- [ ] Verify specialists no longer flag issues on context lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)