### PR TITLE
feat(dedup): show consensus table for cross-specialist findings

### DIFF
--- a/src/vigil/cross_specialist_dedup.py
+++ b/src/vigil/cross_specialist_dedup.py
@@ -6,6 +6,7 @@ This prevents review spam while showing consensus.
 """
 
 import logging
+from dataclasses import dataclass
 from typing import NamedTuple
 
 from .context_manager import (
@@ -19,6 +20,16 @@ from .utils import severity_emoji
 log = logging.getLogger(__name__)
 
 
+@dataclass
+class VerdictInfo:
+    """Verdict info for a specialist on a merged finding."""
+
+    specialist: str
+    verdict: str  # APPROVE | REQUEST_CHANGES
+    category: str  # The category label this specialist used for the finding
+    session_id: str = ""
+
+
 class MergedFinding(NamedTuple):
     """A finding that was flagged by multiple specialists, now merged."""
 
@@ -26,6 +37,7 @@ class MergedFinding(NamedTuple):
     specialists: list[str]  # List of specialist names who flagged it
     count: int  # Number of specialists who flagged it (len(specialists))
     original_findings: list[Finding]  # All original findings before merge
+    verdict_info: list[VerdictInfo] = []  # Verdict details for each specialist
 
 
 def merge_specialist_findings(
@@ -44,20 +56,27 @@ def merge_specialist_findings(
         - deduped_findings: List of findings with cross-specialist duplicates merged
         - merged_info: List of MergedFinding info for each merged group
     """
-    # Collect all specialist findings with attribution
-    specialist_findings: list[tuple[str, Finding]] = []
+    # Collect all specialist findings with attribution and verdict details
+    specialist_findings: list[tuple[str, Finding, PersonaVerdict]] = []
     for v in verdicts:
         for f in v.findings:
-            specialist_findings.append((v.persona, f))
+            specialist_findings.append((v.persona, f, v))
 
     if not specialist_findings:
         return [], []
 
     # Group by fingerprint
-    groups = find_cross_specialist_duplicates(specialist_findings)
+    groups = find_cross_specialist_duplicates(
+        [(name, finding) for name, finding, _ in specialist_findings]
+    )
 
     deduped_findings: list[Finding] = []
     merged_info: list[MergedFinding] = []
+
+    # Build a lookup from (persona, finding_id) to verdict info
+    verdict_lookup: dict[tuple[str, int], tuple[PersonaVerdict, Finding]] = {}
+    for name, finding, verdict in specialist_findings:
+        verdict_lookup[(name, id(finding))] = (verdict, finding)
 
     for fp, group in groups.items():
         if len(group) == 1:
@@ -72,6 +91,20 @@ def merge_specialist_findings(
             # Representative finding: pick highest severity
             rep_finding = max(findings, key=lambda f: _severity_rank(f.severity))
 
+            # Build verdict info for each specialist
+            verdict_infos: list[VerdictInfo] = []
+            for spec_name, spec_finding in group:
+                if (spec_name, id(spec_finding)) in verdict_lookup:
+                    verdict, _ = verdict_lookup[(spec_name, id(spec_finding))]
+                    verdict_infos.append(
+                        VerdictInfo(
+                            specialist=spec_name,
+                            verdict=verdict.decision,
+                            category=spec_finding.category,
+                            session_id=verdict.session_id,
+                        )
+                    )
+
             # Preserve the representative but track the merge
             deduped_findings.append(rep_finding)
             merged_info.append(
@@ -80,6 +113,7 @@ def merge_specialist_findings(
                     specialists=specialists,
                     count=len(specialists),
                     original_findings=findings,
+                    verdict_info=verdict_infos,
                 )
             )
 
@@ -110,40 +144,106 @@ def format_merged_finding_comment(
     finding: Finding,
     specialists: list[str],
     session_ids: dict[str, str] | None = None,
+    verdict_info: list[VerdictInfo] | None = None,
+    total_specialists: int | None = None,
 ) -> str:
     """Format a merged finding for inline comment display.
 
-    Shows which specialists flagged the issue, with their session IDs.
+    Shows which specialists flagged the issue with consensus table for multiple flaggers.
+    Sanitizes LLM-generated content (message, suggestion, category) to prevent XSS.
 
     Args:
         finding: The representative Finding
         specialists: List of specialist names who flagged it
-        session_ids: Optional dict mapping specialist name -> session_id
+        session_ids: Optional dict mapping specialist name -> session_id (deprecated, use verdict_info)
+        verdict_info: List of VerdictInfo objects with verdict details (replaces session_ids approach)
+        total_specialists: Total number of specialists in the review (for consensus count)
 
     Returns:
         Formatted markdown for the merged finding
     """
     icon = severity_emoji(finding.severity)
     session_ids = session_ids or {}
+    verdict_info = verdict_info or []
 
-    # Build specialist attribution with session IDs
-    specialist_lines = []
-    for spec in specialists:
-        sid = session_ids.get(spec)
-        if sid:
-            specialist_lines.append(f"**{spec}** `{sid}`")
-        else:
-            specialist_lines.append(f"**{spec}**")
-    specialist_text = ", ".join(specialist_lines)
-
-    # Build the comment body
-    suggestion = f"\n\n**Suggestion:** {finding.suggestion}" if finding.suggestion else ""
-
-    return (
-        f"{icon} **[{finding.severity.value.upper()}]** [{finding.category}]\n"
-        f"🔍 Flagged by: {specialist_text}\n\n"
-        f"{finding.message}{suggestion}"
+    # Sanitize LLM-generated content to prevent XSS
+    sanitized_message = sanitize_markdown(finding.message)
+    sanitized_suggestion = (
+        sanitize_markdown(finding.suggestion) if finding.suggestion else None
     )
+    sanitized_category = sanitize_markdown(finding.category)
+
+    # Build the main finding section
+    suggestion = (
+        f"\n\n**Suggestion:** {sanitized_suggestion}"
+        if sanitized_suggestion
+        else ""
+    )
+
+    main_body = (
+        f"{icon} **[{finding.severity.value.upper()}]** [{sanitized_category}]\n\n"
+        f"{sanitized_message}{suggestion}"
+    )
+
+    # If only one specialist or no consensus table requested, use simple format
+    if len(specialists) <= 1 or total_specialists is None:
+        # Fall back to simple format with validated specialist names and session IDs
+        specialist_lines = []
+        for spec in specialists:
+            # Validate specialist name for safe embedding
+            safe_name = validate_specialist_name(spec)
+
+            sid = session_ids.get(spec)
+            # Validate session ID
+            safe_sid = validate_session_id(sid) if sid else ""
+
+            if safe_sid:
+                specialist_lines.append(f"**{safe_name}** `{safe_sid}`")
+            else:
+                specialist_lines.append(f"**{safe_name}**")
+        specialist_text = ", ".join(specialist_lines)
+        return (
+            f"{icon} **[{finding.severity.value.upper()}]** [{sanitized_category}]\n"
+            f"🔍 Flagged by: {specialist_text}\n\n"
+            f"{sanitized_message}{suggestion}"
+        )
+
+    # Build consensus table for multiple specialists
+    lines = [main_body]
+    lines.append("\n---\n")
+    lines.append(f"📊 **Consensus ({len(specialists)}/{total_specialists} specialists)**")
+    lines.append("")
+
+    # Build table header and separator
+    lines.append("| Specialist | Verdict | Ref |")
+    lines.append("|------------|---------|-----|")
+
+    # Build table rows from verdict_info if available, otherwise from specialists
+    if verdict_info:
+        for info in verdict_info:
+            # Validate specialist name and session ID
+            safe_name = validate_specialist_name(info.specialist)
+            safe_sid = validate_session_id(info.session_id)
+
+            verdict_emoji = "✅" if info.verdict == "APPROVE" else "🚫"
+            session_id_str = f" `{safe_sid}`" if safe_sid else ""
+            # Sanitize category field in verdict info
+            safe_category = sanitize_markdown(info.category)
+            lines.append(
+                f"| {safe_name}{session_id_str} | {verdict_emoji} {info.verdict} | {safe_category} |"
+            )
+    else:
+        # Fallback: use specialists list without verdict details
+        for spec in specialists:
+            safe_name = validate_specialist_name(spec)
+            sid = session_ids.get(spec)
+            safe_sid = validate_session_id(sid) if sid else ""
+            session_id_str = f" `{safe_sid}`" if safe_sid else ""
+            lines.append(
+                f"| {safe_name}{session_id_str} | — | {sanitized_category} |"
+            )
+
+    return "\n".join(lines)
 
 
 def annotate_findings_with_specialist_context(

--- a/tests/test_cross_round_cross_specialist_integration.py
+++ b/tests/test_cross_round_cross_specialist_integration.py
@@ -8,6 +8,7 @@ from vigil.context_manager import (
     filter_cross_round_duplicates,
 )
 from vigil.cross_specialist_dedup import (
+    VerdictInfo,
     format_merged_finding_comment,
     merge_specialist_findings,
     annotate_findings_with_specialist_context,
@@ -348,3 +349,92 @@ class TestAnnotateWithSpecialistContext:
         unique_item = next((a for a in annotated if not a["is_merged"]), None)
         assert unique_item is not None
         assert unique_item["count"] == 0
+
+
+class TestEndToEndConsensusFlow:
+    """End-to-end test of consensus table generation."""
+
+    def test_consensus_table_end_to_end(self):
+        """Test full flow: merge findings -> format with consensus table."""
+        # Simulate 3 specialists finding the same issue with different category labels
+        f1 = Finding(
+            file="src/adapter.py",
+            line=15,
+            severity=Severity.critical,
+            category="Resource Lifecycle Management",
+            message="The `PlatformAuditAdapter` uses an in-memory `deque` as its WAL buffer, "
+                    "which is lost on process termination. This violates write-ahead logging guarantees.",
+            suggestion="Replace the in-memory `deque` with a persistent storage mechanism.",
+        )
+        f2 = Finding(
+            file="src/adapter.py",
+            line=15,
+            severity=Severity.critical,
+            category="Data Integrity / Compliance",
+            message="The `PlatformAuditAdapter` uses an in-memory `deque` as its WAL buffer, "
+                    "which is lost on process termination. This violates write-ahead logging guarantees.",
+            suggestion="Replace the in-memory `deque` with a persistent storage mechanism.",
+        )
+        f3 = Finding(
+            file="src/adapter.py",
+            line=15,
+            severity=Severity.high,
+            category="Memory Leak / Unbounded Data Structure",
+            message="The `PlatformAuditAdapter` uses an in-memory `deque` as its WAL buffer, "
+                    "which is lost on process termination. This violates write-ahead logging guarantees.",
+            suggestion="Replace the in-memory `deque` with a persistent storage mechanism.",
+        )
+
+        v1 = PersonaVerdict(
+            persona="Architecture",
+            session_id="VGL-ddd629",
+            decision="REQUEST_CHANGES",
+            checks={},
+            findings=[f1],
+            observations=[],
+        )
+        v2 = PersonaVerdict(
+            persona="Testing",
+            session_id="VGL-7dbc2f",
+            decision="REQUEST_CHANGES",
+            checks={},
+            findings=[f2],
+            observations=[],
+        )
+        v3 = PersonaVerdict(
+            persona="Performance",
+            session_id="VGL-62c24e",
+            decision="REQUEST_CHANGES",
+            checks={},
+            findings=[f3],
+            observations=[],
+        )
+
+        # Merge findings
+        deduped, merged = merge_specialist_findings([v1, v2, v3])
+
+        assert len(deduped) == 1, "Should merge 3 findings into 1"
+        assert len(merged) == 1, "Should have 1 merged group"
+        assert merged[0].count == 3, "Should show 3 specialists"
+
+        # Format with consensus table
+        result = format_merged_finding_comment(
+            merged[0].finding,
+            merged[0].specialists,
+            verdict_info=merged[0].verdict_info,
+            total_specialists=6,
+        )
+
+        # Verify consensus table is present and correct
+        assert "📊 **Consensus (3/6 specialists)**" in result
+        assert "Architecture" in result
+        assert "Testing" in result
+        assert "Performance" in result
+        assert "VGL-ddd629" in result
+        assert "VGL-7dbc2f" in result
+        assert "VGL-62c24e" in result
+        assert "Resource Lifecycle Management" in result
+        assert "Data Integrity / Compliance" in result
+        assert "Memory Leak / Unbounded Data Structure" in result
+        assert "PlatformAuditAdapter" in result
+        assert "Replace the in-memory" in result

--- a/tests/test_cross_specialist_dedup.py
+++ b/tests/test_cross_specialist_dedup.py
@@ -4,6 +4,7 @@ import pytest
 
 from vigil.cross_specialist_dedup import (
     MergedFinding,
+    VerdictInfo,
     merge_specialist_findings,
     format_merged_finding_comment,
     _severity_rank,
@@ -232,3 +233,243 @@ class TestMergedFindingNamedTuple:
         assert mf.count == 2
         assert len(mf.specialists) == 2
         assert len(mf.original_findings) == 2
+
+
+class TestConsensusFormatting:
+    """Test consensus table formatting for merged findings."""
+
+    def test_consensus_format_two_specialists(self):
+        """Consensus format should show table for two specialists."""
+        f = Finding(file="src/auth.py", line=42, severity=Severity.high,
+                   category="SQL Injection", message="Dangerous SQL")
+        verdict_info = [
+            VerdictInfo(specialist="Security", verdict="REQUEST_CHANGES",
+                       category="SQL Injection", session_id="VGL-abc123"),
+            VerdictInfo(specialist="Logic", verdict="REQUEST_CHANGES",
+                       category="SQL Injection", session_id="VGL-def456"),
+        ]
+        result = format_merged_finding_comment(
+            f, ["Security", "Logic"],
+            verdict_info=verdict_info,
+            total_specialists=6
+        )
+        assert "📊 **Consensus (2/6 specialists)**" in result
+        assert "| Specialist | Verdict | Ref |" in result
+        assert "| Security `VGL-abc123` | 🚫 REQUEST_CHANGES | SQL Injection |" in result
+        assert "| Logic `VGL-def456` | 🚫 REQUEST_CHANGES | SQL Injection |" in result
+        assert "---" in result
+
+    def test_consensus_format_three_specialists(self):
+        """Consensus format should work with three specialists."""
+        f = Finding(file="src/auth.py", line=42, severity=Severity.high,
+                   category="SQL Injection", message="Dangerous SQL")
+        verdict_info = [
+            VerdictInfo(specialist="Security", verdict="REQUEST_CHANGES",
+                       category="SQL Injection", session_id="VGL-111"),
+            VerdictInfo(specialist="Testing", verdict="REQUEST_CHANGES",
+                       category="Input Validation", session_id="VGL-222"),
+            VerdictInfo(specialist="Performance", verdict="APPROVE",
+                       category="Performance", session_id="VGL-333"),
+        ]
+        result = format_merged_finding_comment(
+            f, ["Security", "Testing", "Performance"],
+            verdict_info=verdict_info,
+            total_specialists=5
+        )
+        assert "📊 **Consensus (3/5 specialists)**" in result
+        assert "Security" in result
+        assert "Testing" in result
+        assert "Performance" in result
+        assert "✅ APPROVE" in result
+
+    def test_consensus_shows_correct_total_count(self):
+        """Consensus should show correct N/TOTAL count."""
+        f = Finding(file="src/auth.py", line=42, severity=Severity.high,
+                   category="SQL Injection", message="Dangerous SQL")
+        verdict_info = [
+            VerdictInfo(specialist="Security", verdict="REQUEST_CHANGES",
+                       category="SQL Injection", session_id="VGL-abc"),
+            VerdictInfo(specialist="Logic", verdict="REQUEST_CHANGES",
+                       category="SQL Injection", session_id="VGL-def"),
+        ]
+        result = format_merged_finding_comment(
+            f, ["Security", "Logic"],
+            verdict_info=verdict_info,
+            total_specialists=8
+        )
+        assert "2/8 specialists" in result
+
+    def test_consensus_includes_verdicts(self):
+        """Consensus table should show verdicts with emojis."""
+        f = Finding(file="src/auth.py", line=42, severity=Severity.high,
+                   category="SQL Injection", message="Dangerous SQL")
+        verdict_info = [
+            VerdictInfo(specialist="Reviewer1", verdict="APPROVE",
+                       category="SQL Injection", session_id="VGL-111"),
+            VerdictInfo(specialist="Reviewer2", verdict="REQUEST_CHANGES",
+                       category="SQL Injection", session_id="VGL-222"),
+        ]
+        result = format_merged_finding_comment(
+            f, ["Reviewer1", "Reviewer2"],
+            verdict_info=verdict_info,
+            total_specialists=3
+        )
+        assert "✅ APPROVE" in result
+        assert "🚫 REQUEST_CHANGES" in result
+
+    def test_consensus_includes_category_refs(self):
+        """Consensus table Ref column should show each specialist's category."""
+        f = Finding(file="src/auth.py", line=42, severity=Severity.high,
+                   category="SQL Injection", message="Dangerous SQL")
+        verdict_info = [
+            VerdictInfo(specialist="Security", verdict="REQUEST_CHANGES",
+                       category="Resource Lifecycle Management", session_id="VGL-ddd629"),
+            VerdictInfo(specialist="Testing", verdict="REQUEST_CHANGES",
+                       category="Data Integrity / Compliance", session_id="VGL-7dbc2f"),
+            VerdictInfo(specialist="Performance", verdict="REQUEST_CHANGES",
+                       category="Memory Leak / Unbounded Data Structure", session_id="VGL-62c24e"),
+        ]
+        result = format_merged_finding_comment(
+            f, ["Security", "Testing", "Performance"],
+            verdict_info=verdict_info,
+            total_specialists=6
+        )
+        assert "Resource Lifecycle Management" in result
+        assert "Data Integrity / Compliance" in result
+        assert "Memory Leak / Unbounded Data Structure" in result
+
+    def test_single_specialist_no_consensus_table(self):
+        """Single specialist should use simple format without consensus table."""
+        f = Finding(file="src/auth.py", line=42, severity=Severity.high,
+                   category="SQL Injection", message="Dangerous SQL")
+        result = format_merged_finding_comment(
+            f, ["Security"],
+            session_ids={"Security": "VGL-abc123"}
+        )
+        assert "Consensus" not in result
+        assert "Flagged by:" in result
+        assert "Security" in result
+
+    def test_no_total_specialists_uses_simple_format(self):
+        """Without total_specialists, should use simple format."""
+        f = Finding(file="src/auth.py", line=42, severity=Severity.high,
+                   category="SQL Injection", message="Dangerous SQL")
+        verdict_info = [
+            VerdictInfo(specialist="Security", verdict="REQUEST_CHANGES",
+                       category="SQL Injection", session_id="VGL-abc"),
+            VerdictInfo(specialist="Logic", verdict="REQUEST_CHANGES",
+                       category="SQL Injection", session_id="VGL-def"),
+        ]
+        result = format_merged_finding_comment(
+            f, ["Security", "Logic"],
+            verdict_info=verdict_info,
+            total_specialists=None  # No total provided
+        )
+        assert "Consensus" not in result
+        assert "Flagged by:" in result
+
+    def test_consensus_includes_main_finding_content(self):
+        """Consensus format should include the main finding message and suggestion."""
+        f = Finding(file="src/auth.py", line=42, severity=Severity.high,
+                   category="SQL Injection", message="Dangerous SQL concatenation",
+                   suggestion="Use parameterized queries")
+        verdict_info = [
+            VerdictInfo(specialist="Security", verdict="REQUEST_CHANGES",
+                       category="SQL Injection", session_id="VGL-abc"),
+            VerdictInfo(specialist="Logic", verdict="REQUEST_CHANGES",
+                       category="SQL Injection", session_id="VGL-def"),
+        ]
+        result = format_merged_finding_comment(
+            f, ["Security", "Logic"],
+            verdict_info=verdict_info,
+            total_specialists=3
+        )
+        assert "Dangerous SQL concatenation" in result
+        assert "Use parameterized queries" in result
+
+    def test_verdict_info_with_empty_session_id(self):
+        """VerdictInfo with empty session_id should not show backticks."""
+        f = Finding(file="src/auth.py", line=42, severity=Severity.high,
+                   category="SQL Injection", message="Dangerous SQL")
+        verdict_info = [
+            VerdictInfo(specialist="Security", verdict="REQUEST_CHANGES",
+                       category="SQL Injection", session_id="VGL-abc"),
+            VerdictInfo(specialist="Logic", verdict="REQUEST_CHANGES",
+                       category="SQL Injection", session_id=""),  # No session ID
+        ]
+        result = format_merged_finding_comment(
+            f, ["Security", "Logic"],
+            verdict_info=verdict_info,
+            total_specialists=3
+        )
+        # Security row should have session ID in backticks
+        assert "Security `VGL-abc`" in result
+        # Logic row should not have backticks
+        assert "| Logic |" in result
+
+
+class TestMergeWithVerdictInfo:
+    """Test merge_specialist_findings populates verdict_info correctly."""
+
+    def test_merged_finding_includes_verdict_info(self):
+        """Merged finding should populate verdict_info from PersonaVerdict."""
+        f1 = Finding(file="src/auth.py", line=42, severity=Severity.high,
+                    category="SQL Injection", message="Dangerous SQL")
+        f2 = Finding(file="src/auth.py", line=42, severity=Severity.high,
+                    category="SQL Injection", message="Dangerous SQL")
+        v1 = PersonaVerdict(
+            persona="Security",
+            session_id="VGL-111111",
+            decision="REQUEST_CHANGES",
+            checks={},
+            findings=[f1],
+            observations=[],
+        )
+        v2 = PersonaVerdict(
+            persona="Logic",
+            session_id="VGL-222222",
+            decision="REQUEST_CHANGES",
+            checks={},
+            findings=[f2],
+            observations=[],
+        )
+        deduped, merged = merge_specialist_findings([v1, v2])
+        assert len(merged) == 1
+        assert len(merged[0].verdict_info) == 2
+
+        # Check verdict info contains expected data
+        verdicts_by_spec = {v.specialist: v for v in merged[0].verdict_info}
+        assert "Security" in verdicts_by_spec
+        assert "Logic" in verdicts_by_spec
+        assert verdicts_by_spec["Security"].verdict == "REQUEST_CHANGES"
+        assert verdicts_by_spec["Security"].session_id == "VGL-111111"
+        assert verdicts_by_spec["Logic"].session_id == "VGL-222222"
+
+    def test_verdict_info_includes_category_from_finding(self):
+        """Verdict info should capture the category from each specialist's finding."""
+        f1 = Finding(file="src/auth.py", line=42, severity=Severity.high,
+                    category="Resource Lifecycle Management", message="Issue")
+        f2 = Finding(file="src/auth.py", line=42, severity=Severity.high,
+                    category="Memory Management", message="Issue")
+        v1 = PersonaVerdict(
+            persona="Architecture",
+            session_id="VGL-arch001",
+            decision="REQUEST_CHANGES",
+            checks={},
+            findings=[f1],
+            observations=[],
+        )
+        v2 = PersonaVerdict(
+            persona="Performance",
+            session_id="VGL-perf001",
+            decision="REQUEST_CHANGES",
+            checks={},
+            findings=[f2],
+            observations=[],
+        )
+        deduped, merged = merge_specialist_findings([v1, v2])
+        assert len(merged) == 1
+
+        verdicts_by_spec = {v.specialist: v for v in merged[0].verdict_info}
+        assert verdicts_by_spec["Architecture"].category == "Resource Lifecycle Management"
+        assert verdicts_by_spec["Performance"].category == "Memory Management"


### PR DESCRIPTION
## Summary
- Adds consensus table format when multiple specialists flag the same finding
- Shows specialist name, verdict (APPROVE/REQUEST_CHANGES), and category reference in a markdown table
- Adds VerdictInfo dataclass to track per-specialist verdict details
- Falls back to simple format when total_specialists not provided (backward compatible)

## Closes
Closes #6

## Test plan
- 11 new consensus-specific tests covering 2, 3+ specialists
- Verdict info population tests verify data flows from PersonaVerdict
- End-to-end integration test matching the issue example
- All 388 tests pass

🤖 Generated with Claude Code