### PR TITLE
fix(ci): run vigil on self-hosted Hetzner runners + venv install

### DIFF
--- a/.github/workflows/vigil.yml
+++ b/.github/workflows/vigil.yml
@@ -9,8 +9,15 @@
 # The built-in GITHUB_TOKEN is used for posting reviews.
 # Since it's a bot account, it CAN approve/request_changes (not your own PR).
 #
-# Trigger: reviews on PR open/reopen/ready. Re-review via `/vigil review` comment.
-# Does NOT auto-review on every commit push.
+# Triggers:
+#   - PR opened/reopened/ready_for_review → full review
+#   - PR synchronize (new commit) → re-review, cancels any in-progress run for the same PR
+#   - `/vigil review` comment → on-demand re-review
+#
+# Runs on the F2iLLC self-hosted runner pool (ci-general). Using GitHub-hosted
+# runners on private F2iLLC repos hits the org Actions billing cap and silently
+# skips the job ("Actions budget is preventing further use"), which is why
+# reviews appear to start but never post deliverables.
 
 name: Vigil PR Review
 
@@ -25,10 +32,15 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   review:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-general]
+    timeout-minutes: 20
+    # One review per PR: a new commit cancels any in-flight review for the same PR.
+    # Only the review job uses this group — dismiss/resolve-addressed run independently
+    # so they aren't cancelled by unrelated commits.
     concurrency:
       group: vigil-review-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: true
@@ -55,14 +67,15 @@ jobs:
             echo "url=${{ github.event.pull_request.html_url }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: F2iProject/vigil@v1
+      - uses: F2iLLC/vigil@v1
         with:
           pr-url: ${{ steps.pr.outputs.url }}
           model: "gemini/gemini-2.5-flash"
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
 
   dismiss:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-general]
+    timeout-minutes: 10
     # Resolve Vigil threads when someone replies "resolved" to an inline comment
     # or posts "resolved" in the PR conversation
     if: >-
@@ -94,20 +107,21 @@ jobs:
         run: |
           echo "url=${{ github.event.pull_request.html_url || github.event.issue.pull_request.html_url }}" >> "$GITHUB_OUTPUT"
 
-      - uses: F2iProject/vigil@v1
+      - uses: F2iLLC/vigil@v1
         with:
           pr-url: ${{ steps.pr.outputs.url }}
           command: dismiss-resolved
 
   resolve-addressed:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-general]
+    timeout-minutes: 10
     # Auto-resolve Vigil threads when code at commented lines changes
     if: >-
       github.event_name == 'pull_request' &&
       github.event.action == 'synchronize' &&
       github.event.pull_request.draft == false
     steps:
-      - uses: F2iProject/vigil@v1
+      - uses: F2iLLC/vigil@v1
         with:
           command: resolve-addressed
           gemini-api-key: ${{ secrets.GEMINI_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ jobs:
 ### Reusable action
 
 ```yaml
-- uses: F2iProject/vigil@main
+- uses: F2iLLC/vigil@v1
   with:
     model: "gemini/gemini-2.5-flash"
     profile: "default"

--- a/action.yml
+++ b/action.yml
@@ -44,14 +44,48 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Python
+    # Resolve a usable Python 3.10+ interpreter. Prefer the system python3 on
+    # self-hosted runners (Hetzner ci-general boxes ship with Python 3.12 and
+    # the venv module), and fall back to actions/setup-python on GitHub-hosted
+    # runners where the toolcache is reliable.
+    - name: Detect Python
+      id: py
+      shell: bash
+      run: |
+        if command -v python3 >/dev/null 2>&1; then
+          PY_VERSION="$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
+          if python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)'; then
+            echo "Found system python3 $PY_VERSION — skipping setup-python"
+            echo "python=$(command -v python3)" >> "$GITHUB_OUTPUT"
+            echo "needs_setup=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+        fi
+        echo "No suitable system python3 — will run actions/setup-python"
+        echo "needs_setup=true" >> "$GITHUB_OUTPUT"
+
+    - name: Set up Python (fallback)
+      if: steps.py.outputs.needs_setup == 'true'
       uses: actions/setup-python@v5
       with:
         python-version: "3.12"
 
-    - name: Install Vigil
+    - name: Install Vigil into a venv
+      id: install
       shell: bash
-      run: pip install "${{ github.action_path }}"
+      run: |
+        set -euo pipefail
+        if [ "${{ steps.py.outputs.needs_setup }}" = "true" ]; then
+          PYTHON_BIN="$(command -v python)"
+        else
+          PYTHON_BIN="${{ steps.py.outputs.python }}"
+        fi
+        VENV_DIR="${RUNNER_TEMP:-/tmp}/vigil-venv-${GITHUB_RUN_ID:-local}"
+        rm -rf "$VENV_DIR"
+        "$PYTHON_BIN" -m venv "$VENV_DIR"
+        "$VENV_DIR/bin/pip" install --upgrade pip
+        "$VENV_DIR/bin/pip" install "${{ github.action_path }}"
+        echo "vigil=$VENV_DIR/bin/vigil" >> "$GITHUB_OUTPUT"
 
     - name: Run Vigil
       shell: bash
@@ -61,6 +95,8 @@ runs:
         OPENAI_API_KEY: ${{ inputs.openai-api-key }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
       run: |
+        set -euo pipefail
+        VIGIL="${{ steps.install.outputs.vigil }}"
         PR_URL="${{ inputs.pr-url }}"
         if [ -z "$PR_URL" ]; then
           PR_URL="${{ github.event.pull_request.html_url }}"
@@ -69,9 +105,9 @@ runs:
         COMMAND="${{ inputs.command }}"
 
         if [ "$COMMAND" = "dismiss-resolved" ]; then
-          vigil dismiss-resolved "$PR_URL"
+          "$VIGIL" dismiss-resolved "$PR_URL"
         elif [ "$COMMAND" = "resolve-addressed" ]; then
-          vigil resolve-addressed "$PR_URL"
+          "$VIGIL" resolve-addressed "$PR_URL"
         else
           ARGS=(
             "$PR_URL"
@@ -82,5 +118,5 @@ runs:
           if [ -n "${{ inputs.lead-model }}" ]; then
             ARGS+=(--lead-model "${{ inputs.lead-model }}")
           fi
-          vigil review "${ARGS[@]}"
+          "$VIGIL" review "${ARGS[@]}"
         fi


### PR DESCRIPTION
## Summary
After the F2iProject → F2iLLC org rename, vigil workflows on private F2iLLC repos started appearing to run but never posted deliverables. Three failure modes were compounding:

1. **Billing cap**: template workflow used `runs-on: ubuntu-latest`. On private F2iLLC repos this hit the org Actions billing cap and jobs silently didn't start (*"Actions budget is preventing further use"*).
2. **Stale org**: template + README still referenced `F2iProject/vigil@v1`.
3. **PEP 668**: `action.yml` ran `pip install` directly against the system interpreter, which is externally-managed on Ubuntu 24.04.

## What changes
- **`.github/workflows/vigil.yml`** — `runs-on: [self-hosted, linux, x64, ci-general]` on all 3 jobs; action ref → `F2iLLC/vigil@v1`; concurrency block moved to job scope (review only) so dismiss / resolve-addressed aren't cancelled by unrelated commits; added `issues: write` permission.
- **`action.yml`** — install into a per-run venv at `$RUNNER_TEMP/vigil-venv-<run_id>`; prefer system python3 on self-hosted (Hetzner boxes ship 3.12 + venv); fall back to `actions/setup-python@v5` only when a suitable system python is absent.
- **`README.md`** — reusable-action snippet updated to `F2iLLC/vigil@v1`.

## Concurrency semantics
Group key is `vigil-review-<pr-number>`, so only runs for the **same** PR share a group:
- Commit A on PR #42 is reviewing → commit B on PR #42 cancels A and starts fresh ✓
- Commit X on PR #43 is unaffected by anything happening on PR #42 ✓
- If all runners are busy, different PRs queue independently — they don't cancel each other.

## Runner-side fix (not in this PR)
`apt install python3.12-venv python3-pip` on hetzner-1..4 so ensurepip is available.

## Test plan
- [ ] Merge this PR, then move the `v1` tag to the merge commit so downstream `@v1` consumers pick it up
- [ ] Verify a PR on bioqms-core (or any F2iLLC repo with the drop-in workflow) produces a posted review
- [ ] Push a second commit during a review → confirm old run cancels, new one starts

Companion PRs: bioqms-core#692, LunaOS#803, relara#304, orbital-eln#8, Discovery#6, praxislms#158, f2i-websites#6, bioqms-io#3, lunaos-io#2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)