### PR TITLE
fix(reviewer): treat specialist 503/timeout as non-blocking observation

### DIFF
--- a/src/vigil/reviewer.py
+++ b/src/vigil/reviewer.py
@@ -74,14 +74,20 @@ def _gen_session_id() -> str:
     return f"VGL-{secrets.token_hex(3)}"
 
 
+def _is_transient_llm_error(e: Exception) -> bool:
+    """Return True for errors indicating temporary LLM infrastructure unavailability."""
+    err_str = str(e).lower()
+    return any(x in err_str for x in ("rate_limit", "429", "503", "service unavailable", "unavailable", "timeout", "timed out"))
+
+
 def _call_llm_with_retry(messages: list[dict], model: str, **kwargs):
-    """Call litellm completion with exponential backoff on rate limits."""
+    """Call litellm completion with exponential backoff on rate limits and transient errors."""
     for attempt in range(MAX_RETRIES):
         try:
             return completion(model=model, messages=messages, **kwargs)
         except Exception as e:
             err_str = str(e).lower()
-            if "rate_limit" in err_str or "429" in err_str:
+            if "rate_limit" in err_str or "429" in err_str or "503" in err_str or "service unavailable" in err_str:
                 wait = INITIAL_BACKOFF * (2 ** attempt)
                 time.sleep(wait)
             else:
@@ -285,23 +291,44 @@ def review_diff(
             if on_specialist_done:
                 on_specialist_done(verdict)
         except Exception as e:
-            verdicts.append(
-                PersonaVerdict(
-                    persona=persona.name,
-                    session_id=_gen_session_id(),
-                    decision="ERROR",
-                    checks={},
-                    findings=[
-                        Finding(
-                            file="N/A",
-                            severity=Severity.medium,
-                            category="reviewer_error",
-                            message=f"Specialist review failed: {e}",
-                        )
-                    ],
-                    observations=[],
+            if _is_transient_llm_error(e):
+                # Transient infra error (503/timeout) — specialist was unavailable, not a code issue.
+                # Emit a non-blocking observation so the lead reviewer is informed but not forced to block.
+                verdicts.append(
+                    PersonaVerdict(
+                        persona=persona.name,
+                        session_id=_gen_session_id(),
+                        decision="APPROVE",
+                        checks={},
+                        findings=[],
+                        observations=[
+                            Finding(
+                                file="N/A",
+                                severity=Severity.low,
+                                category="reviewer_unavailable",
+                                message=f"{persona.name} specialist was temporarily unavailable ({type(e).__name__}). Review skipped — not a code-quality signal.",
+                            )
+                        ],
+                    )
                 )
-            )
+            else:
+                verdicts.append(
+                    PersonaVerdict(
+                        persona=persona.name,
+                        session_id=_gen_session_id(),
+                        decision="ERROR",
+                        checks={},
+                        findings=[
+                            Finding(
+                                file="N/A",
+                                severity=Severity.medium,
+                                category="reviewer_error",
+                                message=f"Specialist review failed: {e}",
+                            )
+                        ],
+                        observations=[],
+                    )
+                )
 
     # --- Step 1.5: Filter known decisions ---
     if repo_key:

--- a/src/vigil/reviewer.py
+++ b/src/vigil/reviewer.py
@@ -77,6 +77,22 @@ def _gen_session_id() -> str:
 def _is_transient_llm_error(e: Exception) -> bool:
     """Return True for errors indicating temporary LLM infrastructure unavailability."""
     err_str = str(e).lower()
+    return _is_retryable_llm_error(err_str)
+
+
+def _is_retryable_llm_error(err: Exception | str) -> bool:
+    """Return True only for provider errors likely to recover with retry."""
+    err_str = str(err).lower()
+    non_retryable_429_markers = (
+        "billing",
+        "quota",
+        "insufficient_quota",
+        "exceeded your current quota",
+        "hard limit",
+        "payment",
+    )
+    if "429" in err_str and any(marker in err_str for marker in non_retryable_429_markers):
+        return False
     return any(x in err_str for x in ("rate_limit", "429", "503", "service unavailable", "unavailable", "timeout", "timed out"))
 
 
@@ -86,8 +102,7 @@ def _call_llm_with_retry(messages: list[dict], model: str, **kwargs):
         try:
             return completion(model=model, messages=messages, **kwargs)
         except Exception as e:
-            err_str = str(e).lower()
-            if "rate_limit" in err_str or "429" in err_str or "503" in err_str or "service unavailable" in err_str:
+            if _is_retryable_llm_error(e):
                 wait = INITIAL_BACKOFF * (2 ** attempt)
                 time.sleep(wait)
             else:
@@ -173,10 +188,18 @@ def _run_lead_review(
                 for f in v.findings
             )
         findings_header = "Findings:\n" + findings_str if findings_str else "No findings."
+        observations_str = ""
+        if v.observations:
+            observations_str = "\n".join(
+                f"  - [{f.severity.value}] {f.file}:{f.line or '?'} -- {f.message}"
+                for f in v.observations
+            )
+        observations_header = "Observations:\n" + observations_str if observations_str else "No observations."
         verdicts_text += f"""
 ### {v.persona} [{v.session_id}]: {v.decision}
 Checks: {checks_str}
 {findings_header}
+{observations_header}
 """
 
     user_message = f"""{pr_block}

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -232,3 +232,98 @@ class TestDecisionFiltering:
 
         # filter_known_findings should have been called
         assert mock_filter.call_count >= 1
+
+
+# ---------- Transient specialist error handling ----------
+
+class TestTransientSpecialistErrors:
+
+    def _make_profile(self):
+        persona = Persona(name="Architecture", focus="Design", system_prompt="You are an architect.")
+        return ReviewProfile(name="test", specialists=[persona], lead_prompt="You are the lead.")
+
+    def _mock_lead_response(self, decision="APPROVE"):
+        resp = {"decision": decision, "summary": "Looks good", "findings": []}
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock(message=MagicMock(content=json.dumps(resp)))]
+        return mock_resp
+
+    def _pr_context(self):
+        return {
+            "title": "Test PR", "author": "user", "head": "feature",
+            "base": "main", "additions": 3, "deletions": 1,
+            "changed_files": 1, "body": "",
+        }
+
+    @patch("vigil.reviewer.send_alerts_for_verdicts")
+    @patch("vigil.reviewer._call_llm_with_retry")
+    def test_503_produces_observation_not_finding(self, mock_llm, mock_alerts):
+        """A 503 from a specialist should produce a non-blocking observation, not a finding."""
+        mock_alerts.return_value = 0
+        lead_json = json.dumps({"decision": "APPROVE", "summary": "Looks good", "findings": []})
+        lead_resp = MagicMock()
+        lead_resp.choices = [MagicMock(message=MagicMock(content=lead_json))]
+        mock_llm.side_effect = [Exception("503 Service Unavailable"), lead_resp]
+
+        profile = self._make_profile()
+        result = review_diff("diff --git a/a.py b/a.py\n", self._pr_context(), profile)
+
+        specialist = result.specialist_verdicts[0]
+        assert specialist.decision == "APPROVE"
+        assert len(specialist.findings) == 0
+        assert len(specialist.observations) == 1
+        assert "unavailable" in specialist.observations[0].message.lower()
+        assert specialist.observations[0].category == "reviewer_unavailable"
+        assert specialist.observations[0].severity == Severity.low
+
+    @patch("vigil.reviewer.send_alerts_for_verdicts")
+    @patch("vigil.reviewer._call_llm_with_retry")
+    def test_503_does_not_block_overall_review(self, mock_llm, mock_alerts):
+        """A 503 specialist error should not cause the overall review to REQUEST_CHANGES."""
+        mock_alerts.return_value = 0
+        lead_json = json.dumps({"decision": "APPROVE", "summary": "Looks good", "findings": []})
+        lead_resp = MagicMock()
+        lead_resp.choices = [MagicMock(message=MagicMock(content=lead_json))]
+        mock_llm.side_effect = [Exception("GeminiException 503 UNAVAILABLE"), lead_resp]
+
+        profile = self._make_profile()
+        result = review_diff("diff --git a/a.py b/a.py\n", self._pr_context(), profile)
+
+        assert result.decision == "APPROVE"
+        assert len(result.lead_findings) == 0
+
+    @patch("vigil.reviewer.send_alerts_for_verdicts")
+    @patch("vigil.reviewer._call_llm_with_retry")
+    def test_timeout_produces_observation_not_finding(self, mock_llm, mock_alerts):
+        """A timeout from a specialist should produce a non-blocking observation."""
+        mock_alerts.return_value = 0
+        lead_json = json.dumps({"decision": "APPROVE", "summary": "Looks good", "findings": []})
+        lead_resp = MagicMock()
+        lead_resp.choices = [MagicMock(message=MagicMock(content=lead_json))]
+        mock_llm.side_effect = [Exception("Request timed out after 30s"), lead_resp]
+
+        profile = self._make_profile()
+        result = review_diff("diff --git a/a.py b/a.py\n", self._pr_context(), profile)
+
+        specialist = result.specialist_verdicts[0]
+        assert specialist.decision == "APPROVE"
+        assert len(specialist.findings) == 0
+        assert specialist.observations[0].category == "reviewer_unavailable"
+
+    @patch("vigil.reviewer.send_alerts_for_verdicts")
+    @patch("vigil.reviewer._call_llm_with_retry")
+    def test_non_transient_error_still_produces_error_finding(self, mock_llm, mock_alerts):
+        """A non-transient error (e.g. bad model config) should still produce an ERROR verdict."""
+        mock_alerts.return_value = 0
+        lead_json = json.dumps({"decision": "APPROVE", "summary": "Looks good", "findings": []})
+        lead_resp = MagicMock()
+        lead_resp.choices = [MagicMock(message=MagicMock(content=lead_json))]
+        mock_llm.side_effect = [Exception("Invalid API key: authentication failed"), lead_resp]
+
+        profile = self._make_profile()
+        result = review_diff("diff --git a/a.py b/a.py\n", self._pr_context(), profile)
+
+        specialist = result.specialist_verdicts[0]
+        assert specialist.decision == "ERROR"
+        assert len(specialist.findings) == 1
+        assert specialist.findings[0].category == "reviewer_error"

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -6,7 +6,7 @@ from unittest.mock import patch, MagicMock
 
 from vigil.models import Finding, PersonaVerdict, ReviewResult, Severity
 from vigil.personas import Persona, ReviewProfile
-from vigil.reviewer import _parse_json_response, _parse_findings, review_diff
+from vigil.reviewer import _parse_json_response, _parse_findings, _is_transient_llm_error, review_diff
 
 
 # ---------- _parse_json_response ----------
@@ -276,6 +276,13 @@ class TestTransientSpecialistErrors:
         assert specialist.observations[0].category == "reviewer_unavailable"
         assert specialist.observations[0].severity == Severity.low
 
+    def test_quota_429_is_not_transient(self):
+        """Quota and billing 429s should remain blocking reviewer errors."""
+        assert not _is_transient_llm_error(
+            Exception("429: You exceeded your current quota, please check your plan and billing details")
+        )
+        assert _is_transient_llm_error(Exception("429 rate_limit: retry after 30 seconds"))
+
     @patch("vigil.reviewer.send_alerts_for_verdicts")
     @patch("vigil.reviewer._call_llm_with_retry")
     def test_503_does_not_block_overall_review(self, mock_llm, mock_alerts):
@@ -327,3 +334,44 @@ class TestTransientSpecialistErrors:
         assert specialist.decision == "ERROR"
         assert len(specialist.findings) == 1
         assert specialist.findings[0].category == "reviewer_error"
+
+    @patch("vigil.reviewer.send_alerts_for_verdicts")
+    @patch("vigil.reviewer._call_llm_with_retry")
+    def test_quota_429_produces_error_finding(self, mock_llm, mock_alerts):
+        """A non-retryable 429 should produce an ERROR verdict, not a skipped specialist."""
+        mock_alerts.return_value = 0
+        lead_json = json.dumps({"decision": "APPROVE", "summary": "Looks good", "findings": []})
+        lead_resp = MagicMock()
+        lead_resp.choices = [MagicMock(message=MagicMock(content=lead_json))]
+        mock_llm.side_effect = [
+            Exception("429: insufficient_quota - check billing details"),
+            lead_resp,
+        ]
+
+        profile = self._make_profile()
+        result = review_diff("diff --git a/a.py b/a.py\n", self._pr_context(), profile)
+
+        specialist = result.specialist_verdicts[0]
+        assert specialist.decision == "ERROR"
+        assert len(specialist.findings) == 1
+        assert specialist.findings[0].category == "reviewer_error"
+        assert len(specialist.observations) == 0
+
+    @patch("vigil.reviewer.send_alerts_for_verdicts")
+    @patch("vigil.reviewer._call_llm_with_retry")
+    def test_specialist_observations_are_sent_to_lead(self, mock_llm, mock_alerts):
+        """Skipped-specialist observations should be visible to the lead reviewer."""
+        mock_alerts.return_value = 0
+        lead_json = json.dumps({"decision": "APPROVE", "summary": "Looks good", "findings": []})
+        lead_resp = MagicMock()
+        lead_resp.choices = [MagicMock(message=MagicMock(content=lead_json))]
+        mock_llm.side_effect = [Exception("503 Service Unavailable"), lead_resp]
+
+        profile = self._make_profile()
+        review_diff("diff --git a/a.py b/a.py\n", self._pr_context(), profile)
+
+        lead_messages = mock_llm.call_args_list[1].kwargs["messages"]
+        lead_prompt = lead_messages[1]["content"]
+        assert "Observations:" in lead_prompt
+        assert "review skipped" in lead_prompt.lower()
+        assert "No findings." in lead_prompt


### PR DESCRIPTION
## Summary
- Transient infra errors (503, service unavailable, timeout) from a specialist now produce a non-blocking `reviewer_unavailable` observation + `APPROVE` instead of a blocking `ERROR` finding
- `_call_llm_with_retry` now also retries on 503/service_unavailable (same backoff as 429), giving the infra a recovery window before degrading
- Non-transient errors (auth failures, bad config) still produce `ERROR` verdicts as before

Fixes #30. Directly unblocks praxislms#177 and similar false-positive blocks across repos.

## Test plan
- [ ] 4 new tests in `TestTransientSpecialistErrors` — all pass
- [ ] 503 → observation (not finding), decision stays APPROVE
- [ ] timeout → same behavior
- [ ] non-transient error (auth fail) → still ERROR verdict
- [ ] `gh pr list --repo F2iLLC/praxislms` — no new vigil blocks from 503s after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)