### PR TITLE
feat(alerts): POST findings to LunaOS /api/escalations alongside email

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Options:
 ```
 vigil dismiss-resolved <PR_URL>
 ```
+
 Resolve Vigil comment threads that received a "resolved" reply. Also logs the decision so the finding pattern is suppressed in future reviews.
 
 ```
@@ -87,6 +88,7 @@ Options:
   --remove INT            Remove a specific decision by ID (re-enables that pattern)
   --clear                 Clear all decisions for the repo
 ```
+
 Browse, filter, and manage the decision log. See what Vigil is suppressing, why each finding was dismissed, and selectively re-enable patterns as the repo matures.
 
 ```
@@ -99,11 +101,13 @@ Options:
   --lead-model TEXT       LLM model for lead reviewer
   --profile TEXT          Review profile
 ```
+
 Start the webhook server to auto-review PRs when they are opened, reopened, or marked ready for review.
 
 ```
 vigil profiles
 ```
+
 List available review profiles and their specialists.
 
 ### Examples
@@ -150,15 +154,18 @@ When `--post` is used, Vigil automatically creates GitHub issues for non-blockin
 Vigil remembers findings you've already acknowledged so it doesn't keep flagging the same patterns:
 
 **How decisions get logged:**
+
 - Reply "resolved", "fixed", "addressed", or "done" to a Vigil inline comment
 - Vigil captures the reply text as the reason and the author as `decided_by`
 - Decision type is inferred: "false positive" → `false_positive`, "wontfix"/"acceptable" → `wontfix`, everything else → `accepted`
 
 **How decisions suppress findings:**
+
 - Before each review, findings are checked against the decision log by (repo, file, category) + fuzzy message matching (≥85% similarity)
 - Matching findings are silently suppressed
 
 **Managing decisions:**
+
 ```bash
 # See what's suppressed and why
 vigil decisions owner/repo
@@ -179,6 +186,7 @@ vigil serve --port 8000 -m gemini/gemini-2.5-flash
 ```
 
 The server listens for GitHub webhook events:
+
 - **PR opened/reopened/ready_for_review** → triggers a review
 - **`/vigil review` comment** → triggers an on-demand review
 - **Resolution replies** → resolves threads and logs decisions
@@ -201,6 +209,19 @@ SMTP_USER=vigil@company.com
 SMTP_PASSWORD=app-specific-password
 ```
 
+Alongside email, the same findings are also POSTed to LunaOS's escalation-gate
+webhook (`/api/escalations`), which fans them out to Telegram. This is
+additive — email alerting works the same whether or not the webhook is
+configured.
+
+```bash
+# .env
+LUNAOS_ESCALATION_URL=https://hetzner-api.lunaos.io/api/escalations
+ESCALATION_INGEST_TOKEN=shared-secret-token
+```
+
+Leave `LUNAOS_ESCALATION_URL` unset to disable the escalation webhook.
+
 ## GitHub Action
 
 ### Drop-in workflow (for your own repo)
@@ -215,7 +236,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  issues: write  # needed for auto-issue creation
+  issues: write # needed for auto-issue creation
 
 jobs:
   review:
@@ -248,14 +269,14 @@ jobs:
 
 ### `default` — 6 specialists + lead
 
-| Specialist | Focus | Blocking |
-|---|---|---|
-| **Logic** | Bugs, off-by-one, null handling, race conditions | Yes |
-| **Security** | Injection, secrets, auth gaps, OWASP top 10 | No (observations → issues) |
-| **Architecture** | Coupling, API design, dependency direction | Yes |
-| **Testing** | Coverage gaps, brittle tests, missing error path tests | Yes |
-| **Performance** | N+1 queries, memory leaks, O(n²) on unbounded data | Yes |
-| **DX** | Breaking changes, missing docs, confusing error messages | Yes |
+| Specialist       | Focus                                                    | Blocking                   |
+| ---------------- | -------------------------------------------------------- | -------------------------- |
+| **Logic**        | Bugs, off-by-one, null handling, race conditions         | Yes                        |
+| **Security**     | Injection, secrets, auth gaps, OWASP top 10              | No (observations → issues) |
+| **Architecture** | Coupling, API design, dependency direction               | Yes                        |
+| **Testing**      | Coverage gaps, brittle tests, missing error path tests   | Yes                        |
+| **Performance**  | N+1 queries, memory leaks, O(n²) on unbounded data       | Yes                        |
+| **DX**           | Breaking changes, missing docs, confusing error messages | Yes                        |
 
 Security runs as **non-blocking** by default — its findings become observations that are tracked as issues rather than blocking the PR. This is ideal for early-stage repos where security patterns aren't yet established. You can change this in `personas.py`.
 
@@ -263,10 +284,10 @@ Security runs as **non-blocking** by default — its findings become observation
 
 Everything in `default`, plus:
 
-| Specialist | Focus | Blocking |
-|---|---|---|
-| **Data Architecture** | Schema design, migrations, indexes, entity ownership | Yes |
-| **GxP Compliance** | Audit trails, ALCOA+, 21 CFR Part 11, immutability | Yes |
+| Specialist            | Focus                                                | Blocking |
+| --------------------- | ---------------------------------------------------- | -------- |
+| **Data Architecture** | Schema design, migrations, indexes, entity ownership | Yes      |
+| **GxP Compliance**    | Audit trails, ALCOA+, 21 CFR Part 11, immutability   | Yes      |
 
 The enterprise profile also includes enhanced specialists with tenant isolation checks, cross-package impact analysis, and regulatory-aware reviews.
 

--- a/src/vigil/alerts.py
+++ b/src/vigil/alerts.py
@@ -1,26 +1,36 @@
 """Email alerting for Vigil findings that require attention.
 
 Sends email alerts for non-blocking specialists (e.g. Security) so findings
-are visible even though they don't block the review.
+are visible even though they don't block the review. Also POSTs the same
+findings to LunaOS's escalation-gate webhook so they surface in the Telegram
+escalation pipeline.
 
 Configuration via environment variables:
-    VIGIL_ALERT_EMAIL    — recipient email address(es), comma-separated
-    SMTP_HOST            — SMTP server hostname (default: smtp.gmail.com)
-    SMTP_PORT            — SMTP server port (default: 587)
-    SMTP_USER            — SMTP username (usually your email)
-    SMTP_PASSWORD        — SMTP password or app password
+    VIGIL_ALERT_EMAIL       — recipient email address(es), comma-separated
+    SMTP_HOST               — SMTP server hostname (default: smtp.gmail.com)
+    SMTP_PORT               — SMTP server port (default: 587)
+    SMTP_USER               — SMTP username (usually your email)
+    SMTP_PASSWORD           — SMTP password or app password
+    LUNAOS_ESCALATION_URL   — LunaOS /api/escalations endpoint URL; unset disables
+                              the webhook delivery path
+    ESCALATION_INGEST_TOKEN — shared secret sent as the X-Escalation-Token header
 """
 
 import logging
 import os
+import re
 import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+
+import httpx
 
 from .models import Finding, PersonaVerdict, Severity
 from .utils import severity_emoji as _severity_emoji
 
 log = logging.getLogger(__name__)
+
+_PR_URL_RE = re.compile(r"^https://github\.com/([^/]+/[^/]+)/pull/(\d+)")
 
 
 def _format_findings_html(findings: list[Finding]) -> str:
@@ -145,6 +155,92 @@ def send_alert(
         return False
 
 
+def send_escalation_webhook(
+    persona_name: str,
+    findings: list[Finding],
+    pr_url: str = "",
+    pr_title: str = "",
+) -> bool:
+    """POST findings from an alert-enabled specialist to LunaOS's escalation gate.
+
+    This feeds the same non-blocking-but-visible findings that `send_alert`
+    emails into LunaOS's `/api/escalations` endpoint, which fans them out to
+    Telegram. See LunaOS `skills/escalation-gate/SKILL.md` for the contract.
+
+    Returns True only on a 2xx response, False otherwise (including when the
+    webhook is not configured, the PR URL can't be parsed, or the request
+    fails) — this must never raise.
+    """
+    escalation_url = os.environ.get("LUNAOS_ESCALATION_URL", "").strip()
+    escalation_token = os.environ.get("ESCALATION_INGEST_TOKEN", "").strip()
+    if not escalation_url or not escalation_token:
+        log.debug("LUNAOS_ESCALATION_URL/ESCALATION_INGEST_TOKEN not set — skipping escalation webhook")
+        return False
+
+    match = _PR_URL_RE.match(pr_url)
+    if not match:
+        log.warning("Cannot parse owner/repo and PR number from pr_url %r — skipping escalation webhook", pr_url)
+        return False
+    repo, pr_number = match.group(1), match.group(2)
+
+    # Count by severity (mirrors send_alert's subject-line logic)
+    crit = sum(1 for f in findings if f.severity == Severity.critical)
+    high = sum(1 for f in findings if f.severity == Severity.high)
+    severity_tag = ""
+    if crit:
+        severity_tag = f"\U0001f534 {crit} CRITICAL"
+    elif high:
+        severity_tag = f"\U0001f7e0 {high} HIGH"
+
+    title = f"Vigil {persona_name} Alert: {len(findings)} finding(s)"
+    if severity_tag:
+        title += f" — {severity_tag}"
+    if pr_title:
+        title += f" in \"{pr_title}\""
+
+    top = findings[0]
+    top_loc = top.file + (f":{top.line}" if top.line else "")
+    reason = f"[{top.severity.value.upper()}] {top_loc} — {top.message}"
+    if len(reason) > 200:
+        reason = reason[:197] + "..."
+
+    payload = {
+        "source": "vigil",
+        "repo": repo,
+        "subjectType": "pr",
+        "subjectId": pr_number,
+        "kind": "needs-human-review",
+        "title": title,
+        "reason": reason,
+        "deepLink": pr_url,
+    }
+
+    try:
+        resp = httpx.post(
+            escalation_url,
+            json=payload,
+            headers={
+                "Content-Type": "application/json",
+                "X-Escalation-Token": escalation_token,
+            },
+            timeout=10,
+        )
+        if 200 <= resp.status_code < 300:
+            log.info(
+                "Escalation webhook sent for %d %s findings on %s#%s",
+                len(findings), persona_name, repo, pr_number,
+            )
+            return True
+        log.warning(
+            "Escalation webhook returned %d for %s#%s: %s",
+            resp.status_code, repo, pr_number, resp.text[:200],
+        )
+        return False
+    except Exception as e:
+        log.warning("Failed to send escalation webhook: %s", e)
+        return False
+
+
 def send_alerts_for_verdicts(
     verdicts: list[PersonaVerdict],
     alert_personas: set[str],
@@ -159,6 +255,10 @@ def send_alerts_for_verdicts(
         pr_url: PR URL for context in the email.
         pr_title: PR title for the email subject.
 
+    Sends both an email alert (send_alert) and, if configured, an escalation
+    webhook POST to LunaOS (send_escalation_webhook) for each alert-enabled
+    verdict with findings. Either delivery succeeding counts toward `sent`.
+
     Returns count of alerts sent.
     """
     sent = 0
@@ -170,6 +270,8 @@ def send_alerts_for_verdicts(
         all_findings = v.findings + v.observations
         if not all_findings:
             continue
-        if send_alert(v.persona, all_findings, pr_url, pr_title):
+        email_sent = send_alert(v.persona, all_findings, pr_url, pr_title)
+        webhook_sent = send_escalation_webhook(v.persona, all_findings, pr_url, pr_title)
+        if email_sent or webhook_sent:
             sent += 1
     return sent

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -10,6 +10,7 @@ from vigil.alerts import (
     _format_findings_text,
     send_alert,
     send_alerts_for_verdicts,
+    send_escalation_webhook,
 )
 from vigil.models import Finding, PersonaVerdict, Severity
 
@@ -145,6 +146,111 @@ class TestSendAlert:
             send_alert("Security", [_make_finding(sev=Severity.critical)])
 
 
+# ---------- send_escalation_webhook ----------
+
+class TestSendEscalationWebhook:
+
+    def test_not_configured_returns_false_no_call(self):
+        env = {"LUNAOS_ESCALATION_URL": "", "ESCALATION_INGEST_TOKEN": ""}
+        with patch.dict(os.environ, env, clear=False):
+            with patch("vigil.alerts.httpx.post") as mock_post:
+                result = send_escalation_webhook(
+                    "Security", [_make_finding()],
+                    pr_url="https://github.com/org/repo/pull/1",
+                )
+        assert result is False
+        mock_post.assert_not_called()
+
+    def test_missing_token_only_returns_false_no_call(self):
+        env = {
+            "LUNAOS_ESCALATION_URL": "https://hetzner-api.lunaos.io/api/escalations",
+            "ESCALATION_INGEST_TOKEN": "",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with patch("vigil.alerts.httpx.post") as mock_post:
+                result = send_escalation_webhook(
+                    "Security", [_make_finding()],
+                    pr_url="https://github.com/org/repo/pull/1",
+                )
+        assert result is False
+        mock_post.assert_not_called()
+
+    def test_malformed_pr_url_returns_false_no_call(self):
+        env = {
+            "LUNAOS_ESCALATION_URL": "https://hetzner-api.lunaos.io/api/escalations",
+            "ESCALATION_INGEST_TOKEN": "secret-token",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with patch("vigil.alerts.httpx.post") as mock_post:
+                result = send_escalation_webhook(
+                    "Security", [_make_finding()],
+                    pr_url="https://example.com/not-a-github-pr",
+                )
+        assert result is False
+        mock_post.assert_not_called()
+
+    @patch("vigil.alerts.httpx.post")
+    def test_posts_with_expected_url_headers_and_payload(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        env = {
+            "LUNAOS_ESCALATION_URL": "https://hetzner-api.lunaos.io/api/escalations",
+            "ESCALATION_INGEST_TOKEN": "secret-token",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            result = send_escalation_webhook(
+                "Security",
+                [_make_finding()],
+                pr_url="https://github.com/org/repo/pull/42",
+                pr_title="Add auth module",
+            )
+
+        assert result is True
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        assert args[0] == "https://hetzner-api.lunaos.io/api/escalations"
+        assert kwargs["headers"]["X-Escalation-Token"] == "secret-token"
+        assert kwargs["headers"]["Content-Type"] == "application/json"
+        assert kwargs["timeout"] == 10
+
+        payload = kwargs["json"]
+        assert payload["source"] == "vigil"
+        assert payload["repo"] == "org/repo"
+        assert payload["subjectType"] == "pr"
+        assert payload["subjectId"] == "42"
+        assert payload["kind"] == "needs-human-review"
+        assert "Security" in payload["title"]
+        assert payload["deepLink"] == "https://github.com/org/repo/pull/42"
+        assert "SQL injection" in payload["reason"]
+
+    @patch("vigil.alerts.httpx.post")
+    def test_non_2xx_response_returns_false(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=400, text="bad source value")
+        env = {
+            "LUNAOS_ESCALATION_URL": "https://hetzner-api.lunaos.io/api/escalations",
+            "ESCALATION_INGEST_TOKEN": "secret-token",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            result = send_escalation_webhook(
+                "Security", [_make_finding()],
+                pr_url="https://github.com/org/repo/pull/42",
+            )
+        assert result is False
+
+    @patch("vigil.alerts.httpx.post")
+    def test_request_exception_returns_false_not_raised(self, mock_post):
+        mock_post.side_effect = Exception("connection refused")
+        env = {
+            "LUNAOS_ESCALATION_URL": "https://hetzner-api.lunaos.io/api/escalations",
+            "ESCALATION_INGEST_TOKEN": "secret-token",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            result = send_escalation_webhook(
+                "Security", [_make_finding()],
+                pr_url="https://github.com/org/repo/pull/42",
+            )
+        assert result is False
+
+
 # ---------- send_alerts_for_verdicts ----------
 
 class TestSendAlertsForVerdicts:
@@ -214,3 +320,54 @@ class TestSendAlertsForVerdicts:
             "Security", [_make_finding()],
             "https://github.com/o/r/pull/1", "My PR",
         )
+
+    def test_both_email_and_webhook_attempted(self):
+        """Both delivery paths (email + escalation webhook) are attempted
+        for each alert-enabled verdict with findings."""
+        verdicts = [
+            PersonaVerdict(
+                persona="Security", decision="APPROVE",
+                checks={}, findings=[], observations=[_make_finding()],
+            ),
+        ]
+        with patch("vigil.alerts.send_alert", return_value=True) as mock_email, \
+             patch("vigil.alerts.send_escalation_webhook", return_value=True) as mock_webhook:
+            sent = send_alerts_for_verdicts(
+                verdicts, {"Security"},
+                pr_url="https://github.com/o/r/pull/1", pr_title="My PR",
+            )
+
+        assert sent == 1
+        mock_email.assert_called_once_with(
+            "Security", [_make_finding()], "https://github.com/o/r/pull/1", "My PR",
+        )
+        mock_webhook.assert_called_once_with(
+            "Security", [_make_finding()], "https://github.com/o/r/pull/1", "My PR",
+        )
+
+    def test_counts_once_when_only_webhook_succeeds(self):
+        """If email fails but the webhook succeeds, it still counts as sent."""
+        verdicts = [
+            PersonaVerdict(
+                persona="Security", decision="APPROVE",
+                checks={}, findings=[], observations=[_make_finding()],
+            ),
+        ]
+        with patch("vigil.alerts.send_alert", return_value=False), \
+             patch("vigil.alerts.send_escalation_webhook", return_value=True):
+            sent = send_alerts_for_verdicts(verdicts, {"Security"})
+
+        assert sent == 1
+
+    def test_counts_zero_when_both_fail(self):
+        verdicts = [
+            PersonaVerdict(
+                persona="Security", decision="APPROVE",
+                checks={}, findings=[], observations=[_make_finding()],
+            ),
+        ]
+        with patch("vigil.alerts.send_alert", return_value=False), \
+             patch("vigil.alerts.send_escalation_webhook", return_value=False):
+            sent = send_alerts_for_verdicts(verdicts, {"Security"})
+
+        assert sent == 0


### PR DESCRIPTION
## Summary
- Adds `send_escalation_webhook()` in `src/vigil/alerts.py` as a second, additive delivery path for alert-enabled persona findings (e.g. Security) — POSTs the same findings that already go out over email to LunaOS's `/api/escalations` endpoint, which fans out to Telegram.
- `send_alerts_for_verdicts()` now calls both `send_alert()` (existing, unchanged) and `send_escalation_webhook()` (new) for each alert-enabled verdict with findings; either succeeding counts toward the returned `sent` total. Email delivery is untouched.
- New env vars (unset = feature disabled, degrades to a logged no-op, never raises): `LUNAOS_ESCALATION_URL` (full endpoint URL) and `ESCALATION_INGEST_TOKEN` (shared secret, sent as `X-Escalation-Token`).
- `owner/repo` and PR number are parsed out of `pr_url` (`^https://github\.com/([^/]+/[^/]+)/pull/(\d+)`); a malformed URL logs a warning and returns `False` rather than guessing.
- README updated with the two new env vars, following the existing "Email Alerts" section style.

This is part of the F2iLLC/LunaOS `pr-escalation-path` project's Phase 3 (plan: `ai/projects/pr-escalation-path/MASTER_SCHEDULE.md`) — the vigil-side sender for Yesenia's Telegram escalation pipeline.

**Dependency note:** this depends on a companion F2iLLC/LunaOS PR that extends the `/api/escalations` schema to accept `"vigil"` as an allowed `source` value. That dependency does **not** block merging this PR — without it deployed, the webhook call simply gets a 400 from LunaOS, `send_escalation_webhook` logs a warning and returns `False`, and email alerting is unaffected either way.

## Test plan
- [x] `pytest tests/` — 429 passed (26 in `tests/test_alerts.py`, including 6 new tests for `send_escalation_webhook` and 3 new tests extending `send_alerts_for_verdicts` coverage for the dual-delivery path)
- [x] No ruff/mypy configuration exists in this repo (checked `pyproject.toml` and `.github/workflows/`) — nothing to run
- [x] Verified only `src/vigil/alerts.py`, `tests/test_alerts.py`, and `README.md` are touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xx5i7sh84LCMGwpqnNy4tQ