### PR TITLE
chore: bump default review model to gemini-3.1-flash-lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,16 +110,16 @@ List available review profiles and their specialists.
 
 ```bash
 # Use Gemini Flash (fast + cheap)
-vigil review https://github.com/org/repo/pull/42 -m gemini/gemini-2.5-flash --post
+vigil review https://github.com/org/repo/pull/## -m gemini/gemini-3.1-flash-lite --post
 
 # Use Claude for lead, Gemini for specialists
-vigil review https://github.com/org/repo/pull/42 -m gemini/gemini-2.5-flash --lead-model claude-sonnet-4-6 --post
+vigil review https://github.com/org/repo/pull/## -m gemini/gemini-3.1-flash-lite --lead-model claude-sonnet-4-6 --post
 
 # Enterprise profile (adds GxP, Data Architecture, tenant isolation reviewers)
-vigil review https://github.com/org/repo/pull/42 -p enterprise --post
+vigil review https://github.com/org/repo/pull/## -p enterprise --post
 
 # JSON output for piping into other tools
-vigil review https://github.com/org/repo/pull/42 --json
+vigil review https://github.com/org/repo/pull/## --json
 
 # Browse decision log
 vigil decisions F2iProject/vigil

--- a/src/vigil/webhook.py
+++ b/src/vigil/webhook.py
@@ -123,7 +123,7 @@ def _run_dismiss(pr_url: str):
 
 def create_app(
     webhook_secret: Optional[str] = None,
-    model: str = "gemini/gemini-2.5-flash",
+    model: str = "gemini/gemini-3.1-flash-lite",
     lead_model: Optional[str] = None,
     profile: str = "default",
 ) -> FastAPI:


### PR DESCRIPTION
## Summary
- Updates the default review model in `webhook.py` from `gemini/gemini-2.5-flash` to `gemini/gemini-3.1-flash-lite`
- Updates README example commands to match

## Test plan
- [ ] Confirm `gemini-3.1-flash-lite` is a valid/available model id
- [ ] Run a review through the webhook path to confirm the new default works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFZwDSCNQzMMexzg6QLhbv