### PR TITLE
Auto-approve docs-only PRs

### DIFF
--- a/src/vigil/diff_parser.py
+++ b/src/vigil/diff_parser.py
@@ -4,6 +4,7 @@ import bisect
 import fnmatch
 import re
 from dataclasses import dataclass
+from pathlib import PurePosixPath
 
 
 @dataclass
@@ -12,6 +13,38 @@ class FileHunk:
     path: str
     header: str  # the diff --git line + index/mode lines
     content: str  # the actual diff hunks
+
+
+DOC_FILE_GLOBS = (
+    "*.md",
+    "*.mdx",
+    "*.rst",
+    "*.txt",
+    "README",
+    "README.*",
+    "CHANGELOG",
+    "CHANGELOG.*",
+    "CONTRIBUTING",
+    "CONTRIBUTING.*",
+    "CODE_OF_CONDUCT",
+    "CODE_OF_CONDUCT.*",
+    "LICENSE",
+    "LICENSE.*",
+    "NOTICE",
+    "NOTICE.*",
+)
+
+DOC_PATH_PREFIXES = (
+    "docs/",
+    "documentation/",
+    ".github/ISSUE_TEMPLATE/",
+)
+
+DOC_PATH_GLOBS = (
+    ".github/pull_request_template.md",
+    ".github/PULL_REQUEST_TEMPLATE.md",
+    ".github/PULL_REQUEST_TEMPLATE/*.md",
+)
 
 
 def parse_diff(raw_diff: str) -> list[FileHunk]:
@@ -48,6 +81,23 @@ def parse_diff(raw_diff: str) -> list[FileHunk]:
         hunks.append(FileHunk(path=path, header=header, content=content))
 
     return hunks
+
+
+def is_documentation_path(path: str) -> bool:
+    """Return True when a changed file is documentation-only."""
+    normalized = path.replace("\\", "/").lstrip("/")
+    basename = PurePosixPath(normalized).name
+
+    if any(normalized.startswith(prefix) for prefix in DOC_PATH_PREFIXES):
+        return True
+    if any(fnmatch.fnmatch(normalized, pattern) for pattern in DOC_PATH_GLOBS):
+        return True
+    return any(fnmatch.fnmatch(basename, pattern) for pattern in DOC_FILE_GLOBS)
+
+
+def is_documentation_only(hunks: list[FileHunk]) -> bool:
+    """Return True when every changed file in the diff is documentation-only."""
+    return bool(hunks) and all(is_documentation_path(hunk.path) for hunk in hunks)
 
 
 def filter_hunks(hunks: list[FileHunk], patterns: list[str]) -> list[FileHunk]:

--- a/src/vigil/reviewer.py
+++ b/src/vigil/reviewer.py
@@ -8,7 +8,7 @@ from typing import Callable
 from litellm import completion
 
 from .alerts import send_alerts_for_verdicts
-from .diff_parser import diff_summary, filter_hunks, parse_diff, reassemble_diff
+from .diff_parser import diff_summary, filter_hunks, is_documentation_only, parse_diff, reassemble_diff
 from .models import Finding, PersonaVerdict, ReviewResult, Severity
 from .personas import Persona, ReviewProfile
 
@@ -269,6 +269,33 @@ def review_diff(
     all_hunks = parse_diff(diff)
     full_summary = diff_summary(all_hunks)
 
+    if is_documentation_only(all_hunks):
+        verdicts = [
+            PersonaVerdict(
+                persona=persona.name,
+                session_id=_gen_session_id(),
+                decision="APPROVE",
+                checks={"documentation_only": "PASS"},
+                findings=[],
+                observations=[],
+            )
+            for persona in profile.specialists
+        ]
+        for verdict in verdicts:
+            if on_specialist_done:
+                on_specialist_done(verdict)
+
+        return ReviewResult(
+            decision="APPROVE",
+            summary="Documentation-only changes detected; Vigil auto-approved without model review.",
+            commit_sha=pr_context.get("head_sha", ""),
+            pr_url=pr_context.get("url", ""),
+            model=model,
+            specialist_verdicts=verdicts,
+            lead_findings=[],
+            observations=[],
+            observation_sources=[],
+        )
     # --- Step 1: Sequential specialist reviews ---
     # Each specialist gets only the files matching their patterns
     verdicts: list[PersonaVerdict] = []

--- a/tests/test_diff_parser.py
+++ b/tests/test_diff_parser.py
@@ -5,6 +5,8 @@ import pytest
 from vigil.diff_parser import (
     commentable_lines,
     find_best_file_for_finding,
+    is_documentation_only,
+    is_documentation_path,
     nearest_commentable_line,
     parse_diff,
 )
@@ -154,3 +156,54 @@ class TestCommentableLinesIntegration:
         # A line NOT in the diff — should snap to nearest
         result = nearest_commentable_line("src/app.py", 20, valid)
         assert result is not None
+
+
+class TestDocumentationOnlyDetection:
+
+    def test_markdown_and_docs_paths_are_documentation(self):
+        assert is_documentation_path("README.md")
+        assert is_documentation_path("docs/setup/install.md")
+        assert is_documentation_path(".github/ISSUE_TEMPLATE/bug.md")
+        assert is_documentation_path(".github/PULL_REQUEST_TEMPLATE/release.md")
+
+    def test_runtime_path_is_not_documentation(self):
+        assert not is_documentation_path("src/app.py")
+        assert not is_documentation_path("packages/core/src/index.ts")
+
+    def test_all_documentation_hunks_are_documentation_only(self):
+        diff = """\
+diff --git a/README.md b/README.md
+index 1111111..2222222 100644
+--- a/README.md
++++ b/README.md
+@@ -1 +1,2 @@
+ # Vigil
++More docs
+diff --git a/docs/setup.md b/docs/setup.md
+index 1111111..2222222 100644
+--- a/docs/setup.md
++++ b/docs/setup.md
+@@ -1 +1,2 @@
+ # Setup
++Install steps
+"""
+        assert is_documentation_only(parse_diff(diff))
+
+    def test_mixed_hunks_are_not_documentation_only(self):
+        diff = """\
+diff --git a/README.md b/README.md
+index 1111111..2222222 100644
+--- a/README.md
++++ b/README.md
+@@ -1 +1,2 @@
+ # Vigil
++More docs
+diff --git a/src/app.py b/src/app.py
+index 1111111..2222222 100644
+--- a/src/app.py
++++ b/src/app.py
+@@ -1 +1,2 @@
+ print("hi")
++print("bye")
+"""
+        assert not is_documentation_only(parse_diff(diff))

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -375,3 +375,49 @@ class TestTransientSpecialistErrors:
         assert "Observations:" in lead_prompt
         assert "review skipped" in lead_prompt.lower()
         assert "No findings." in lead_prompt
+
+
+class TestDocumentationOnlyAutoApprove:
+
+    @patch("vigil.reviewer.send_alerts_for_verdicts")
+    @patch("vigil.reviewer._call_llm_with_retry")
+    def test_documentation_only_pr_auto_approves_without_llm(self, mock_llm, mock_alerts):
+        profile = ReviewProfile(
+            name="test",
+            specialists=[
+                Persona(name="Security", focus="Security", system_prompt="Review security"),
+                Persona(name="DX", focus="Docs", system_prompt="Review docs"),
+            ],
+            lead_prompt="Lead",
+        )
+        pr_context = {
+            "title": "Update docs",
+            "author": "user",
+            "head": "docs-branch",
+            "base": "main",
+            "additions": 2,
+            "deletions": 0,
+            "changed_files": 1,
+            "body": "",
+            "head_sha": "abcdef123456",
+            "url": "https://github.com/o/r/pull/1",
+        }
+        diff = """\
+diff --git a/docs/setup.md b/docs/setup.md
+index 1111111..2222222 100644
+--- a/docs/setup.md
++++ b/docs/setup.md
+@@ -1 +1,2 @@
+ # Setup
++New install step
+"""
+
+        result = review_diff(diff, pr_context, profile)
+
+        assert result.decision == "APPROVE"
+        assert "Documentation-only" in result.summary
+        assert len(result.specialist_verdicts) == 2
+        assert all(v.decision == "APPROVE" for v in result.specialist_verdicts)
+        assert all(v.checks == {"documentation_only": "PASS"} for v in result.specialist_verdicts)
+        mock_llm.assert_not_called()
+        mock_alerts.assert_not_called()


### PR DESCRIPTION
## What changed

Vigil now detects documentation-only pull requests from the parsed diff and returns an `APPROVE` review result before dispatching specialist or lead model review.

The documentation classifier covers common top-level docs files, `docs/` and `documentation/` paths, issue templates, and pull request templates. Mixed docs plus runtime changes still follow the normal review path.

## Why

Documentation-only PRs were effectively being skipped by downstream workflows or review routing. This makes the behavior explicit in Vigil itself: docs-only changes get a real approval review without spending model calls.

## Impact

Users get an actual GitHub approval on docs-only PRs. Runtime-impacting PRs are unchanged.

## Validation

- `git diff --check`
- Targeted tests: `42 passed`
- Full test suite with lightweight `litellm` test stub: `434 passed, 1 warning`