### PR TITLE
Feed PR conversation into specialist and lead review context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **PR conversation context** — Specialists and the lead reviewer now receive the PR's conversation thread (issue comments, bot replies, prior review bodies) alongside the diff, not just the diff itself. A shared "FACTUAL CLAIMS VS. THREAD EVIDENCE" instruction (specialists) and scope-check bullet (lead) direct reviewers to flag a `factual-accuracy` finding when the diff/description asserts something the thread already contradicts — e.g. a doc change claiming "X was never connected" when a bot reply in the same thread says otherwise. Fixes the class of failure in #2698 (LunaOS) where a diff-only review approved a PR whose central factual claim was contradicted in its own comment thread.
 - **Webhook server** — `vigil serve` starts a FastAPI server that receives GitHub webhook events and triggers reviews automatically. No more GitHub Actions minutes burned. Configure with `WEBHOOK_SECRET` for signature verification.
 - **Non-blocking specialists** — Personas can be marked `blocking=False` (Security is non-blocking by default during early dev). Their findings become observations and don't block the review decision.
 - **Email alerts** — Personas with `alert=True` trigger email notifications for their findings. Security findings send alerts even though they're non-blocking. Configure with `VIGIL_ALERT_EMAIL` and SMTP env vars.

--- a/src/vigil/cli.py
+++ b/src/vigil/cli.py
@@ -11,7 +11,10 @@ from rich.table import Table
 
 from .audit import write_audit_entry
 from .comment_manager import (
+    build_conversation_context,
+    fetch_all_pr_reviews,
     fetch_all_vigil_comments,
+    fetch_pr_conversation_comments,
     fetch_vigil_comments,
     get_last_reviewed_sha,
     resolve_addressed_threads,
@@ -127,6 +130,20 @@ def review(
         f"{pr_data['changed_files']} files[/dim]"
     )
     console.print(f"[dim]Profile: {review_profile.name} ({len(review_profile.specialists)} specialists)[/dim]\n")
+
+    # Fetch PR conversation (comments + prior reviews) so specialists and the
+    # lead reviewer can cross-check factual claims in the diff/description
+    # against what's already been said in the thread. Best-effort: a fetch
+    # failure degrades to no conversation context, not a review failure.
+    try:
+        conversation_comments = fetch_pr_conversation_comments(owner, repo, pr_number, token)
+        conversation_reviews = fetch_all_pr_reviews(owner, repo, pr_number, token)
+        pr_data["conversation"] = build_conversation_context(conversation_comments, conversation_reviews)
+        if pr_data["conversation"]:
+            console.print(f"[dim]{len(conversation_comments)} conversation comment(s), {len(conversation_reviews)} review(s) fetched for context[/dim]")
+    except Exception as e:
+        console.print(f"[dim yellow]Could not fetch PR conversation: {e}[/dim yellow]")
+        pr_data["conversation"] = ""
 
     # --- Pre-review pipeline: incremental review, resolve, dedup ---
     last_sha = None

--- a/src/vigil/comment_manager.py
+++ b/src/vigil/comment_manager.py
@@ -80,6 +80,101 @@ def fetch_all_pr_comments(owner: str, repo: str, pr_number: int, token: str) -> 
     return _paginate(url, _github_headers(token))
 
 
+def fetch_pr_conversation_comments(owner: str, repo: str, pr_number: int, token: str) -> list[dict]:
+    """Fetch top-level PR conversation comments (the Conversation tab).
+
+    A pull request is a GitHub issue under the hood. Inline diff comments live
+    under /pulls/{n}/comments (see fetch_all_pr_comments); general discussion,
+    bot replies (e.g. a connector announcing it reviews PRs), and non-review
+    commentary live under /issues/{n}/comments instead. This is where a claim
+    made in the diff or PR body can be contradicted by something already said
+    in the thread.
+    """
+    url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/comments"
+    return _paginate(url, _github_headers(token))
+
+
+def fetch_all_pr_reviews(owner: str, repo: str, pr_number: int, token: str) -> list[dict]:
+    """Fetch all PR reviews (not just Vigil's), for their summary bodies.
+
+    Prior review verdicts are also conversation evidence — a PR that reasserts
+    something a previous review already addressed should be checked against it.
+    """
+    url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/reviews"
+    return _paginate(url, _github_headers(token))
+
+
+_MAX_CONVERSATION_CHARS = 6000
+_MAX_CONVERSATION_ITEM_CHARS = 800
+
+
+def build_conversation_context(
+    comments: list[dict],
+    reviews: list[dict] | None = None,
+    max_total_chars: int = _MAX_CONVERSATION_CHARS,
+    max_item_chars: int = _MAX_CONVERSATION_ITEM_CHARS,
+) -> str:
+    """Format PR conversation comments + review summaries for specialist context.
+
+    Returns chronologically-ordered, truncated plain text — empty string if
+    there's nothing to show. Items are dropped (not further truncated) once
+    the total budget is exhausted, with a note of how many were omitted, so
+    the most recent thread activity is always preserved in favor of older
+    entries when a PR has an unusually long history.
+    """
+    items: list[tuple[str, str, str, str]] = []  # (timestamp, author, body, kind)
+
+    for c in comments:
+        body = (c.get("body") or "").strip()
+        if not body:
+            continue
+        items.append((
+            c.get("created_at", ""),
+            c.get("user", {}).get("login", "unknown"),
+            body,
+            "comment",
+        ))
+
+    for r in reviews or []:
+        body = (r.get("body") or "").strip()
+        if not body:
+            continue
+        state = (r.get("state") or "").lower()
+        items.append((
+            r.get("submitted_at", ""),
+            r.get("user", {}).get("login", "unknown"),
+            body,
+            f"review:{state}" if state else "review",
+        ))
+
+    if not items:
+        return ""
+
+    items.sort(key=lambda item: item[0])
+
+    # Fill the budget from most recent backwards, so a long thread keeps its
+    # latest activity (where a claim is most likely to have been contradicted
+    # or resolved) instead of losing it to older entries filling the quota.
+    kept: list[str] = []
+    total = 0
+    omitted = 0
+    for created_at, author, body, kind in reversed(items):
+        if len(body) > max_item_chars:
+            body = body[:max_item_chars] + " …[truncated]"
+        entry = f"**{author}** ({kind}, {created_at}):\n{body}"
+        if total + len(entry) > max_total_chars:
+            omitted += 1
+            continue
+        kept.append(entry)
+        total += len(entry)
+
+    entries = list(reversed(kept))
+    if omitted:
+        entries.insert(0, f"…[{omitted} earlier thread item(s) omitted for length]")
+
+    return "\n\n---\n\n".join(entries)
+
+
 def get_last_reviewed_sha(owner: str, repo: str, pr_number: int, token: str) -> str | None:
     """Find the most recent Vigil review and return its commit SHA."""
     reviews = fetch_vigil_reviews(owner, repo, pr_number, token)

--- a/src/vigil/personas.py
+++ b/src/vigil/personas.py
@@ -66,6 +66,19 @@ DOMAIN SOVEREIGNTY:
   Good: "External input at this boundary must be machine-validated before use"
 - If your finding requires action in another reviewer's domain, express it as a
   constraint that the lead reviewer can route, not a directive.
+
+FACTUAL CLAIMS VS. THREAD EVIDENCE:
+- If a "PR Conversation" section is provided below, it is what has ALREADY
+  BEEN SAID in this PR's thread (comments, bot replies, prior reviews) — not
+  code, but evidence.
+- If the diff, PR description, or a doc/plan change asserts something as fact
+  (e.g. "X was never configured", "Y always behaves like Z") and the
+  conversation contains evidence that contradicts it, that is a finding —
+  category "factual-accuracy". Severity high if the false claim is being
+  written into a document, plan, or record of truth (docs, CHANGELOG,
+  compliance/audit files); medium otherwise.
+- A logically correct implementation of a false claim is still a bug. Do not
+  let clean code style suppress this check.
 """
 
 
@@ -451,6 +464,11 @@ You have received specialist verdicts from domain reviewers who already analyzed
 Your job is NOT to re-review their domains. Instead:
 
 1. Review SCOPE: Does the PR do what it claims? Any out-of-scope changes?
+   Cross-check factual claims in the diff/description against the "PR
+   Conversation" section — a bot reply or comment already sitting in this
+   PR's thread can falsify a claim the diff makes. Treat a contradiction as
+   a finding even if no specialist caught it (specialists check their own
+   domain's code, not the diff's assertions against the thread).
 2. Review CONVENTIONS: Commit messages, naming, file structure.
 3. CONFLICT DETECTION: Do any specialist findings contradict each other?
 4. Final DECISION: Consolidate all specialist verdicts + your own findings.
@@ -509,6 +527,11 @@ Do NOT re-review their domains. Your role as FINAL GATE:
 3. CONFLICT DETECTION: Do any specialist findings contradict each other?
 4. CODE REVIEW: Clarity, maintainability, architecture alignment (your own assessment).
 5. SCOPE COMPLIANCE: Does PR implement the claimed milestone/task? Any scope drift?
+   Cross-check factual claims in the diff/description against the "PR
+   Conversation" section — a bot reply or comment already sitting in this
+   PR's thread can falsify a claim the diff makes. This applies with extra
+   weight when the claim is being written into a plan of record, audit
+   trail, or compliance document.
 6. COMMIT CONVENTIONS: Conventional commits format with traceability.
 7. REGRESSION RISK: Could this change break existing functionality?
 

--- a/src/vigil/reviewer.py
+++ b/src/vigil/reviewer.py
@@ -121,6 +121,19 @@ def _build_pr_context_block(diff: str, pr_context: dict, file_summary: str = "")
 {file_summary}
 ```
 """
+    conversation_section = ""
+    conversation = pr_context.get("conversation") or ""
+    if conversation:
+        conversation_section = f"""
+### PR Conversation (comments, bot replies, prior reviews)
+This is what has ALREADY BEEN SAID in this PR's thread — treat it as evidence,
+not code. If the diff, description, or a doc/plan change asserts something as
+fact that this conversation contradicts, that is a finding (category
+"factual-accuracy") even if the code itself is otherwise correct.
+```
+{conversation}
+```
+"""
     return f"""## PR: {pr_context['title']}
 
 **Author:** {pr_context['author']}
@@ -129,7 +142,7 @@ def _build_pr_context_block(diff: str, pr_context: dict, file_summary: str = "")
 
 ### Description
 {pr_context.get('body') or 'No description provided.'}
-{summary_section}
+{summary_section}{conversation_section}
 ### Diff (files relevant to your domain)
 ```diff
 {diff}
@@ -249,6 +262,10 @@ def review_diff(
     Args:
         diff: Raw unified diff text.
         pr_context: Dict with PR metadata (title, author, head, base, etc.).
+            An optional "conversation" key (str, from comment_manager.build_
+            conversation_context) is included in every specialist and lead
+            prompt so factual claims in the diff can be cross-checked against
+            the PR's comment thread and prior reviews.
         profile: The ReviewProfile containing specialists and lead prompt.
         model: LLM model identifier for specialists (default: gemini/gemini-2.5-flash).
         lead_model: Optional separate model for the lead reviewer.

--- a/tests/test_comment_manager.py
+++ b/tests/test_comment_manager.py
@@ -9,6 +9,7 @@ from vigil.comment_manager import (
     _is_resolution_reply,
     _issue_covers_finding,
     _parse_finding_from_comment,
+    build_conversation_context,
     deduplicate_comments,
     is_duplicate_finding,
     resolve_threads_batch,
@@ -364,6 +365,84 @@ class TestIssueCoversFinding:
         issue = {"title": "Fix bug", "body": "Fix it"}
         finding = ""
         assert _issue_covers_finding(issue, finding) is True  # benefit of doubt
+
+
+# ---------- build_conversation_context ----------
+
+class TestBuildConversationContext:
+
+    def test_empty_inputs_returns_empty_string(self):
+        assert build_conversation_context([], []) == ""
+        assert build_conversation_context([], None) == ""
+
+    def test_includes_comment_author_and_body(self):
+        comments = [{
+            "created_at": "2026-07-15T10:00:00Z",
+            "user": {"login": "codex-bot"},
+            "body": "Your team has set up Codex to review pull requests in this repo.",
+        }]
+        result = build_conversation_context(comments)
+        assert "codex-bot" in result
+        assert "Codex to review pull requests" in result
+
+    def test_skips_blank_body_comments(self):
+        comments = [
+            {"created_at": "2026-07-15T10:00:00Z", "user": {"login": "a"}, "body": "   "},
+            {"created_at": "2026-07-15T10:01:00Z", "user": {"login": "b"}, "body": "real comment"},
+        ]
+        result = build_conversation_context(comments)
+        assert "real comment" in result
+        assert "**a**" not in result
+
+    def test_includes_review_body_with_state(self):
+        reviews = [{
+            "submitted_at": "2026-07-15T11:00:00Z",
+            "user": {"login": "reviewer1"},
+            "state": "APPROVED",
+            "body": "LGTM overall",
+        }]
+        result = build_conversation_context([], reviews)
+        assert "reviewer1" in result
+        assert "review:approved" in result
+        assert "LGTM overall" in result
+
+    def test_skips_reviews_without_body(self):
+        reviews = [{
+            "submitted_at": "2026-07-15T11:00:00Z",
+            "user": {"login": "reviewer1"},
+            "state": "APPROVED",
+            "body": "",
+        }]
+        assert build_conversation_context([], reviews) == ""
+
+    def test_chronological_ordering(self):
+        comments = [
+            {"created_at": "2026-07-15T12:00:00Z", "user": {"login": "later"}, "body": "second"},
+            {"created_at": "2026-07-15T10:00:00Z", "user": {"login": "earlier"}, "body": "first"},
+        ]
+        result = build_conversation_context(comments)
+        assert result.index("first") < result.index("second")
+
+    def test_truncates_long_item(self):
+        comments = [{
+            "created_at": "2026-07-15T10:00:00Z",
+            "user": {"login": "verbose"},
+            "body": "x" * 2000,
+        }]
+        result = build_conversation_context(comments, max_item_chars=100)
+        assert "truncated" in result
+        assert len(result) < 2000
+
+    def test_drops_oldest_items_when_over_budget(self):
+        comments = [
+            {"created_at": f"2026-07-15T{h:02d}:00:00Z", "user": {"login": f"u{h}"}, "body": "x" * 200}
+            for h in range(10)
+        ]
+        result = build_conversation_context(comments, max_total_chars=500, max_item_chars=200)
+        # Most recent author should survive, oldest should be dropped
+        assert "u9" in result
+        assert "u0" not in result
+        assert "omitted for length" in result
 
 
 # ---------- _parse_finding_from_comment ----------

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -6,7 +6,13 @@ from unittest.mock import patch, MagicMock
 
 from vigil.models import Finding, PersonaVerdict, ReviewResult, Severity
 from vigil.personas import Persona, ReviewProfile
-from vigil.reviewer import _parse_json_response, _parse_findings, _is_transient_llm_error, review_diff
+from vigil.reviewer import (
+    _build_pr_context_block,
+    _is_transient_llm_error,
+    _parse_findings,
+    _parse_json_response,
+    review_diff,
+)
 
 
 # ---------- _parse_json_response ----------
@@ -53,6 +59,35 @@ class TestParseFindings:
                 "category": "test", "message": "msg"}]
         findings = _parse_findings(raw)
         assert findings[0].line is None
+
+
+# ---------- _build_pr_context_block ----------
+
+class TestBuildPrContextBlock:
+
+    def _pr_context(self, **overrides):
+        base = {
+            "title": "Test PR", "author": "user", "head": "feature",
+            "base": "main", "additions": 10, "deletions": 5,
+            "changed_files": 1, "body": "Test",
+        }
+        base.update(overrides)
+        return base
+
+    def test_omits_conversation_section_when_absent(self):
+        block = _build_pr_context_block("diff", self._pr_context())
+        assert "PR Conversation" not in block
+
+    def test_omits_conversation_section_when_empty_string(self):
+        block = _build_pr_context_block("diff", self._pr_context(conversation=""))
+        assert "PR Conversation" not in block
+
+    def test_includes_conversation_section_when_present(self):
+        convo = "**codex-bot** (comment, 2026-07-15T10:00:00Z):\nYour team has set up Codex to review pull requests."
+        block = _build_pr_context_block("diff", self._pr_context(conversation=convo))
+        assert "PR Conversation" in block
+        assert "codex-bot" in block
+        assert "treat it as evidence" in block
 
 
 # ---------- Non-blocking persona logic in review_diff ----------
@@ -375,6 +410,32 @@ class TestTransientSpecialistErrors:
         assert "Observations:" in lead_prompt
         assert "review skipped" in lead_prompt.lower()
         assert "No findings." in lead_prompt
+
+    @patch("vigil.reviewer.send_alerts_for_verdicts")
+    @patch("vigil.reviewer._call_llm_with_retry")
+    def test_conversation_reaches_specialist_and_lead_prompts(self, mock_llm, mock_alerts):
+        """pr_context['conversation'] should flow into both specialist and lead prompts."""
+        mock_alerts.return_value = 0
+        specialist_json = json.dumps({"decision": "APPROVE", "findings": [], "observations": []})
+        specialist_resp = MagicMock()
+        specialist_resp.choices = [MagicMock(message=MagicMock(content=specialist_json))]
+        lead_json = json.dumps({"decision": "APPROVE", "summary": "Looks good", "findings": []})
+        lead_resp = MagicMock()
+        lead_resp.choices = [MagicMock(message=MagicMock(content=lead_json))]
+        mock_llm.side_effect = [specialist_resp, lead_resp]
+
+        profile = self._make_profile()
+        pr_context = self._pr_context()
+        pr_context["conversation"] = (
+            "**codex-bot** (comment, 2026-07-15T10:00:00Z):\n"
+            "Your team has set up Codex to review pull requests in this repo."
+        )
+        review_diff("diff --git a/a.py b/a.py\n", pr_context, profile)
+
+        specialist_prompt = mock_llm.call_args_list[0].kwargs["messages"][1]["content"]
+        lead_prompt = mock_llm.call_args_list[1].kwargs["messages"][1]["content"]
+        assert "codex-bot" in specialist_prompt
+        assert "codex-bot" in lead_prompt
 
 
 class TestDocumentationOnlyAutoApprove:


### PR DESCRIPTION
## Summary

- Fixes F2iLLC/LunaOS#2698 — Vigil's specialists and lead reviewer only ever saw the diff, so a factual claim in a diff/description already contradicted by a comment, bot reply, or prior review in the same PR thread went undetected (LunaOS #2672 approved a false claim into a GxP plan of record, 6/6 specialists, 0 findings).
- `comment_manager.py`: new `fetch_pr_conversation_comments` (issue-comments endpoint — the actual Conversation tab, distinct from inline diff comments), `fetch_all_pr_reviews`, and `build_conversation_context` (bounded, chronological formatting, keeps the most recent items when over budget).
- `reviewer.py`: `_build_pr_context_block` now includes a "PR Conversation" section (from `pr_context["conversation"]`) in every specialist and lead prompt when present.
- `personas.py`: shared `VERDICT_SCHEMA` gets a "FACTUAL CLAIMS VS. THREAD EVIDENCE" instruction (all specialists); both lead prompts get a scope-check bullet to cross-check diff claims against the thread, weighted higher for docs/plans/compliance records.
- `cli.py`: `review` command fetches conversation comments + reviews before running the review, best-effort (fetch failure degrades to no conversation context, not a review failure).

## Test plan

- [x] `python -m pytest` — 446/446 passing (added 12 new tests: `build_conversation_context` formatting/truncation/ordering, `_build_pr_context_block` conversation section, end-to-end conversation flowing into specialist + lead LLM prompts)
- [x] `ruff check` on all changed files — no new issues (4 pre-existing unrelated findings on `main` untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vi3QuTK4Su5LT9B55XZrL