### PR TITLE
chore: update default model to gemini-3.1-flash-lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ That's it. Vigil fetches the PR, runs all specialists, and posts a review with i
 vigil review <PR_URL> [OPTIONS]
 
 Options:
-  -m, --model TEXT        LLM model (default: gemini/gemini-2.5-flash)
+  -m, --model TEXT        LLM model (default: gemini/gemini-3.1-flash-lite)
   --lead-model TEXT       Different model for the lead reviewer
   -p, --profile TEXT      Review profile: default, enterprise
   --json                  Output raw JSON instead of pretty-printing
@@ -182,7 +182,7 @@ vigil decisions owner/repo --clear
 Deploy Vigil as a webhook to auto-review PRs:
 
 ```bash
-vigil serve --port 8000 -m gemini/gemini-2.5-flash
+vigil serve --port 8000 -m gemini/gemini-3.1-flash-lite
 ```
 
 The server listens for GitHub webhook events:
@@ -251,8 +251,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
-          vigil review "${{ github.event.pull_request.html_url }}" \
-            --model "gemini/gemini-2.5-flash" --post
+            vigil review "${{ github.event.pull_request.html_url }}" \
+            --model "gemini/gemini-3.1-flash-lite" --post
 ```
 
 ### Reusable action
@@ -260,7 +260,7 @@ jobs:
 ```yaml
 - uses: F2iLLC/vigil@v1
   with:
-    model: "gemini/gemini-2.5-flash"
+    model: "gemini/gemini-3.1-flash-lite"
     profile: "default"
     gemini-api-key: ${{ secrets.GEMINI_API_KEY }}
 ```
@@ -305,8 +305,8 @@ Anything [litellm supports](https://docs.litellm.ai/docs/providers):
 
 ```bash
 # Google
-vigil review $PR -m gemini/gemini-2.5-flash
-vigil review $PR -m gemini/gemini-2.5-pro
+vigil review $PR -m gemini/gemini-3.1-flash-lite
+vigil review $PR -m gemini/gemini-3.1-pro
 
 # Anthropic
 vigil review $PR -m claude-sonnet-4-6

--- a/action.yml
+++ b/action.yml
@@ -16,9 +16,9 @@ inputs:
     required: false
     default: "review"
   model:
-    description: "LLM model for specialists (litellm format, e.g. gemini/gemini-2.5-flash)"
+    description: "LLM model for specialists (litellm format, e.g. gemini/gemini-3.1-flash-lite)"
     required: false
-    default: "gemini/gemini-2.5-flash"
+    default: "gemini/gemini-3.1-flash-lite"
   lead-model:
     description: "LLM model for lead reviewer (defaults to --model value)"
     required: false

--- a/src/vigil/cli.py
+++ b/src/vigil/cli.py
@@ -95,7 +95,7 @@ def _print_findings(findings: list[Finding], title: str):
 @app.command()
 def review(
     pr_url: str = typer.Argument(help="GitHub PR URL"),
-    model: str = typer.Option("gemini/gemini-2.5-flash", "--model", "-m", help="LLM model for specialists"),
+    model: str = typer.Option("gemini/gemini-3.1-flash-lite", "--model", "-m", help="LLM model for specialists"),
     lead_model: str = typer.Option(None, "--lead-model", help="LLM model for lead reviewer (defaults to --model)"),
     profile: str = typer.Option("default", "--profile", "-p", help="Review profile: default, enterprise"),
     output_json: bool = typer.Option(False, "--json", help="Output raw JSON result"),
@@ -399,7 +399,7 @@ def resolve_addressed(
 def serve(
     port: int = typer.Option(8000, "--port", "-p", help="Port to listen on"),
     host: str = typer.Option("0.0.0.0", "--host", help="Host to bind to"),
-    model: str = typer.Option("gemini/gemini-2.5-flash", "--model", "-m", help="LLM model for reviews"),
+    model: str = typer.Option("gemini/gemini-3.1-flash-lite", "--model", "-m", help="LLM model for reviews"),
     lead_model: str = typer.Option(None, "--lead-model", help="LLM model for lead reviewer"),
     profile: str = typer.Option("default", "--profile", help="Review profile"),
 ):

--- a/src/vigil/reviewer.py
+++ b/src/vigil/reviewer.py
@@ -245,7 +245,7 @@ def review_diff(
     diff: str,
     pr_context: dict,
     profile: ReviewProfile,
-    model: str = "gemini/gemini-2.5-flash",
+    model: str = "gemini/gemini-3.1-flash-lite",
     lead_model: str | None = None,
     on_specialist_done: Callable[[PersonaVerdict], None] | None = None,
     repo_key: str = "",
@@ -267,7 +267,7 @@ def review_diff(
             prompt so factual claims in the diff can be cross-checked against
             the PR's comment thread and prior reviews.
         profile: The ReviewProfile containing specialists and lead prompt.
-        model: LLM model identifier for specialists (default: gemini/gemini-2.5-flash).
+        model: LLM model identifier for specialists (default: gemini/gemini-3.1-flash-lite).
         lead_model: Optional separate model for the lead reviewer.
         on_specialist_done: Optional callback invoked after each specialist finishes.
         repo_key: Repository in "owner/repo" format. When provided, findings are


### PR DESCRIPTION
Updates default model references from gemini-2.5-flash to gemini-3.1-flash-lite in the codebase (CLI options, reviewer module, action description).