### PR TITLE
fix: route Vigil observations to High Priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Each specialist only sees the files relevant to their domain (Security skips `.m
 - **Model-agnostic** — runs on any LLM via [litellm](https://github.com/BerriAI/litellm) (Gemini, Claude, GPT, Mistral, local models, etc.)
 - **Multi-persona review** — 6 specialist reviewers + lead, each with domain-scoped expertise
 - **Inline PR comments** — findings posted directly on the diff lines, not buried in a wall of text
-- **Auto-issue creation** — non-blocking observations are opened as GitHub issues with a `vigil` label and cited as links in the review
+- **Auto-issue creation** — non-blocking observations are opened as GitHub issues with a priority label matching their severity and cited as links in the review
 - **Decision log** — remembers acknowledged findings so Vigil stops re-flagging them; browse and manage via `vigil decisions`
 - **Non-blocking personas** — Security runs as non-blocking by default (findings become observations, never block the PR)
 - **Email alerts** — alert-enabled personas can send email notifications for findings via SMTP
@@ -138,8 +138,8 @@ vigil serve --port 9000 -m gemini/gemini-3.1-flash-lite
 
 When `--post` is used, Vigil automatically creates GitHub issues for non-blocking observations:
 
-1. Each observation becomes an issue labeled `vigil` with severity, file location, message, and suggestion
-2. Existing open `vigil` issues are checked first to avoid duplicates (file path + message similarity matching)
+1. Each observation becomes an issue labeled `Critical Priority`, `High Priority`, `Medium Priority`, or `Low Priority`, matching its severity
+2. Existing open Vigil-created issues are checked first to avoid duplicates (file path + message similarity matching)
 3. The review body shows compact issue links instead of raw text:
 
 ```

--- a/src/vigil/issue_manager.py
+++ b/src/vigil/issue_manager.py
@@ -1,7 +1,7 @@
 """GitHub issue creation for non-blocking observations.
 
 Automatically creates GitHub issues for observations and deduplicates
-against existing open issues with the 'vigil' label.
+against all existing open issues using Vigil's body marker.
 """
 
 import difflib
@@ -15,25 +15,34 @@ from .utils import extract_message_content, github_headers, severity_emoji
 
 log = logging.getLogger(__name__)
 
-_VIGIL_LABEL = "vigil"
-_VIGIL_LABEL_COLOR = "6f42c1"
-_VIGIL_LABEL_DESCRIPTION = "Auto-created by Vigil — AI-powered PR review"
+_PRIORITY_LABELS: dict[Severity, tuple[str, str, str]] = {
+    Severity.critical: ("Critical Priority", "b60205", "Requires immediate attention"),
+    Severity.high: ("High Priority", "d93f0b", "Requires prompt attention"),
+    Severity.medium: ("Medium Priority", "fbca04", "Important, but not urgent"),
+    Severity.low: ("Low Priority", "0e8a16", "Useful follow-up when capacity allows"),
+}
 
 # Marker in issue body to identify Vigil-created issues
 _VIGIL_ISSUE_MARKER = "<!-- vigil-observation -->"
 
 
-def ensure_vigil_label(owner: str, repo: str, token: str) -> bool:
-    """Create the 'vigil' label if it doesn't exist. Returns True if created or exists."""
+def priority_label_for(finding: Finding) -> str:
+    """Return the priority label that corresponds to a finding's severity."""
+    return _PRIORITY_LABELS[finding.severity][0]
+
+
+def ensure_priority_label(owner: str, repo: str, token: str, severity: Severity) -> bool:
+    """Create the severity's priority label if needed. Returns True if created or exists."""
+    name, color, description = _PRIORITY_LABELS[severity]
     url = f"https://api.github.com/repos/{owner}/{repo}/labels"
     try:
         resp = httpx.post(
             url,
             headers=github_headers(token),
             json={
-                "name": _VIGIL_LABEL,
-                "color": _VIGIL_LABEL_COLOR,
-                "description": _VIGIL_LABEL_DESCRIPTION,
+                "name": name,
+                "color": color,
+                "description": description,
             },
             timeout=10,
         )
@@ -96,15 +105,15 @@ def _build_issue_body(
     return "\n".join(sections)
 
 
-def _fetch_all_vigil_issues(
+def _fetch_all_issues(
     owner: str, repo: str, token: str,
 ) -> list[dict]:
-    """Fetch all open issues with the 'vigil' label, paginating through all pages.
+    """Fetch all open issues, paginating through all pages.
 
     Returns a list of issue dicts from the GitHub API.
     """
     url: str | None = f"https://api.github.com/repos/{owner}/{repo}/issues"
-    params: dict | None = {"labels": _VIGIL_LABEL, "state": "open", "per_page": "100"}
+    params: dict | None = {"state": "open", "per_page": "100"}
     all_issues: list[dict] = []
 
     try:
@@ -174,9 +183,9 @@ def find_existing_issue(
     persona: str,
     existing_issues: list[dict] | None = None,
 ) -> str | None:
-    """Check if an open Vigil issue already exists for this finding.
+    """Check if an open Vigil-created issue already exists for this finding.
 
-    Searches open issues with the 'vigil' label, matches by:
+    Searches all open issues for the Vigil body marker, then matches by:
     1. File path appearing in the body
     2. Message similarity >= 0.85
 
@@ -191,7 +200,7 @@ def find_existing_issue(
     Returns the issue HTML URL if found, None otherwise.
     """
     if existing_issues is None:
-        existing_issues = _fetch_all_vigil_issues(owner, repo, token)
+        existing_issues = _fetch_all_issues(owner, repo, token)
     return _match_finding_to_issue(finding, existing_issues)
 
 
@@ -216,7 +225,7 @@ def create_issue(
             json={
                 "title": title,
                 "body": body,
-                "labels": [_VIGIL_LABEL],
+                "labels": [priority_label_for(finding)],
             },
             timeout=15,
         )
@@ -238,7 +247,7 @@ def create_issues_for_observations(
 ) -> list[tuple[Finding, str]]:
     """Create GitHub issues for all observations in the review result.
 
-    Pre-fetches all existing open Vigil issues once to avoid N+1 API calls,
+    Pre-fetches all existing open issues once to avoid N+1 API calls,
     then deduplicates each observation against the cache before creating.
     Groups observations with their source persona from specialist verdicts.
 
@@ -254,11 +263,12 @@ def create_issues_for_observations(
     if not result.observations:
         return []
 
-    # Ensure the vigil label exists
-    ensure_vigil_label(owner, repo, token)
+    # Ensure every priority label that will be used exists before creating issues.
+    for severity in {obs.severity for obs in result.observations}:
+        ensure_priority_label(owner, repo, token, severity)
 
-    # Pre-fetch all open Vigil issues once (avoids N+1 API calls)
-    existing_issues = _fetch_all_vigil_issues(owner, repo, token)
+    # Pre-fetch all open issues once (avoids N+1 API calls)
+    existing_issues = _fetch_all_issues(owner, repo, token)
 
     # Build persona lookup from observation_sources if available
     persona_map: dict[int, str] = {}

--- a/tests/test_issue_manager.py
+++ b/tests/test_issue_manager.py
@@ -6,14 +6,14 @@ from unittest.mock import patch, MagicMock
 from vigil.issue_manager import (
     _build_issue_body,
     _build_issue_title,
-    _fetch_all_vigil_issues,
+    _fetch_all_issues,
     _match_finding_to_issue,
     _VIGIL_ISSUE_MARKER,
-    _VIGIL_LABEL,
     create_issue,
     create_issues_for_observations,
-    ensure_vigil_label,
+    ensure_priority_label,
     find_existing_issue,
+    priority_label_for,
 )
 from vigil.models import Finding, PersonaVerdict, ReviewResult, Severity
 
@@ -143,29 +143,48 @@ class TestBuildIssueBody:
         assert "Performance" in body
 
 
-# ---------- ensure_vigil_label ----------
+# ---------- ensure_priority_label ----------
 
 class TestEnsureVigilLabel:
 
     @patch("vigil.issue_manager.httpx.post")
     def test_creates_label_successfully(self, mock_post):
         mock_post.return_value = MagicMock(status_code=201)
-        assert ensure_vigil_label("owner", "repo", "token") is True
+        assert ensure_priority_label("owner", "repo", "token", Severity.high) is True
 
     @patch("vigil.issue_manager.httpx.post")
     def test_label_already_exists(self, mock_post):
         mock_post.return_value = MagicMock(status_code=422)
-        assert ensure_vigil_label("owner", "repo", "token") is True
+        assert ensure_priority_label("owner", "repo", "token", Severity.high) is True
 
     @patch("vigil.issue_manager.httpx.post")
     def test_api_error(self, mock_post):
         mock_post.return_value = MagicMock(status_code=403, text="Forbidden")
-        assert ensure_vigil_label("owner", "repo", "token") is False
+        assert ensure_priority_label("owner", "repo", "token", Severity.high) is False
 
     @patch("vigil.issue_manager.httpx.post")
     def test_network_error(self, mock_post):
         mock_post.side_effect = Exception("Connection refused")
-        assert ensure_vigil_label("owner", "repo", "token") is False
+        assert ensure_priority_label("owner", "repo", "token", Severity.high) is False
+
+    @patch("vigil.issue_manager.httpx.post")
+    def test_uses_matching_priority_label(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=201)
+        ensure_priority_label("owner", "repo", "token", Severity.low)
+        assert mock_post.call_args.kwargs["json"]["name"] == "Low Priority"
+
+
+@pytest.mark.parametrize(
+    ("severity", "expected"),
+    [
+        (Severity.critical, "Critical Priority"),
+        (Severity.high, "High Priority"),
+        (Severity.medium, "Medium Priority"),
+        (Severity.low, "Low Priority"),
+    ],
+)
+def test_priority_label_matches_severity(severity, expected):
+    assert priority_label_for(_make_finding(sev=severity)) == expected
 
 
 # ---------- _match_finding_to_issue ----------
@@ -219,7 +238,7 @@ class TestFindExistingIssue:
         url = find_existing_issue("o", "r", "token", f, "Logic", existing_issues=issues)
         assert url is None
 
-    @patch("vigil.issue_manager._fetch_all_vigil_issues")
+    @patch("vigil.issue_manager._fetch_all_issues")
     def test_fetches_when_no_prefetched(self, mock_fetch):
         f = _make_finding()
         mock_fetch.return_value = []
@@ -228,7 +247,7 @@ class TestFindExistingIssue:
         mock_fetch.assert_called_once_with("o", "r", "token")
 
 
-# ---------- _fetch_all_vigil_issues (pagination) ----------
+# ---------- _fetch_all_issues (pagination) ----------
 
 class TestFetchAllVigilIssues:
 
@@ -245,8 +264,9 @@ class TestFetchAllVigilIssues:
         mock_client.__exit__ = MagicMock(return_value=False)
         mock_client_cls.return_value = mock_client
 
-        issues = _fetch_all_vigil_issues("o", "r", "token")
+        issues = _fetch_all_issues("o", "r", "token")
         assert len(issues) == 2
+        assert mock_client.get.call_args.kwargs["params"] == {"state": "open", "per_page": "100"}
 
     @patch("vigil.issue_manager.httpx.Client")
     def test_pagination_follows_links(self, mock_client_cls):
@@ -268,7 +288,7 @@ class TestFetchAllVigilIssues:
         mock_client.__exit__ = MagicMock(return_value=False)
         mock_client_cls.return_value = mock_client
 
-        issues = _fetch_all_vigil_issues("o", "r", "token")
+        issues = _fetch_all_issues("o", "r", "token")
         assert len(issues) == 2
         assert mock_client.get.call_count == 2
 
@@ -280,7 +300,7 @@ class TestFetchAllVigilIssues:
         mock_client.__exit__ = MagicMock(return_value=False)
         mock_client_cls.return_value = mock_client
 
-        issues = _fetch_all_vigil_issues("o", "r", "token")
+        issues = _fetch_all_issues("o", "r", "token")
         assert issues == []
 
 
@@ -303,7 +323,7 @@ class TestCreateIssue:
         # Verify the request payload
         call_kwargs = mock_post.call_args
         payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
-        assert _VIGIL_LABEL in payload["labels"]
+        assert payload["labels"] == ["Medium Priority"]
         assert "[Vigil/Security]" in payload["title"]
         assert _VIGIL_ISSUE_MARKER in payload["body"]
 
@@ -325,8 +345,8 @@ class TestCreateIssuesForObservations:
         assert issues == []
 
     @patch("vigil.issue_manager.create_issue")
-    @patch("vigil.issue_manager._fetch_all_vigil_issues")
-    @patch("vigil.issue_manager.ensure_vigil_label")
+    @patch("vigil.issue_manager._fetch_all_issues")
+    @patch("vigil.issue_manager.ensure_priority_label")
     def test_creates_new_issues(self, mock_label, mock_fetch, mock_create):
         mock_label.return_value = True
         mock_fetch.return_value = []  # No existing issues
@@ -341,8 +361,8 @@ class TestCreateIssuesForObservations:
         mock_create.assert_called_once()
 
     @patch("vigil.issue_manager.create_issue")
-    @patch("vigil.issue_manager._fetch_all_vigil_issues")
-    @patch("vigil.issue_manager.ensure_vigil_label")
+    @patch("vigil.issue_manager._fetch_all_issues")
+    @patch("vigil.issue_manager.ensure_priority_label")
     def test_deduplicates_against_existing(self, mock_label, mock_fetch, mock_create):
         mock_label.return_value = True
         mock_fetch.return_value = [
@@ -358,8 +378,8 @@ class TestCreateIssuesForObservations:
         mock_create.assert_not_called()  # Should NOT create a new issue
 
     @patch("vigil.issue_manager.create_issue")
-    @patch("vigil.issue_manager._fetch_all_vigil_issues")
-    @patch("vigil.issue_manager.ensure_vigil_label")
+    @patch("vigil.issue_manager._fetch_all_issues")
+    @patch("vigil.issue_manager.ensure_priority_label")
     def test_uses_observation_sources_for_persona(self, mock_label, mock_fetch, mock_create):
         mock_label.return_value = True
         mock_fetch.return_value = []
@@ -377,8 +397,8 @@ class TestCreateIssuesForObservations:
         assert call_args[1].get("persona") or call_args[0][4] == "Performance"
 
     @patch("vigil.issue_manager.create_issue")
-    @patch("vigil.issue_manager._fetch_all_vigil_issues")
-    @patch("vigil.issue_manager.ensure_vigil_label")
+    @patch("vigil.issue_manager._fetch_all_issues")
+    @patch("vigil.issue_manager.ensure_priority_label")
     def test_handles_create_failure_gracefully(self, mock_label, mock_fetch, mock_create):
         mock_label.return_value = True
         mock_fetch.return_value = []
@@ -391,8 +411,8 @@ class TestCreateIssuesForObservations:
         assert len(issues) == 0  # Failed creation means no issue returned
 
     @patch("vigil.issue_manager.create_issue")
-    @patch("vigil.issue_manager._fetch_all_vigil_issues")
-    @patch("vigil.issue_manager.ensure_vigil_label")
+    @patch("vigil.issue_manager._fetch_all_issues")
+    @patch("vigil.issue_manager.ensure_priority_label")
     def test_multiple_observations(self, mock_label, mock_fetch, mock_create):
         mock_label.return_value = True
         mock_fetch.return_value = []
@@ -417,8 +437,8 @@ class TestCreateIssuesForObservations:
         assert mock_create.call_count == 2
 
     @patch("vigil.issue_manager.create_issue")
-    @patch("vigil.issue_manager._fetch_all_vigil_issues")
-    @patch("vigil.issue_manager.ensure_vigil_label")
+    @patch("vigil.issue_manager._fetch_all_issues")
+    @patch("vigil.issue_manager.ensure_priority_label")
     def test_prefetches_issues_once(self, mock_label, mock_fetch, mock_create):
         """Verify issues are fetched once (not per observation) to avoid N+1."""
         mock_label.return_value = True


### PR DESCRIPTION
## Summary
- label each auto-created observation according to its existing severity: **Critical**, **High**, **Medium**, or **Low Priority**
- do not add a igil label
- preserve duplicate detection through the existing Vigil body marker, independent of labels

## Verification
- python -m pytest -q (451 passed)