### PR TITLE
[codex] require actionable review observations

### DIFF
--- a/src/vigil/personas.py
+++ b/src/vigil/personas.py
@@ -22,7 +22,8 @@ Respond with valid JSON matching this schema:
     }
   ],
   "observations": [
-    same shape as findings — non-blocking notes worth tracking as future issues
+    same shape as findings — non-blocking problems worth tracking as future issues.
+    Unlike findings, every observation MUST include a concrete, non-null suggestion.
   ]
 }
 
@@ -30,6 +31,7 @@ Rules:
 - If you have no findings, return "decision": "APPROVE" with empty findings list.
 - Only return REQUEST_CHANGES if there are high or critical severity findings.
 - Be specific: file paths, line numbers, concrete suggestions.
+- Observations without a concrete action are invalid and will be discarded.
 
 CHANGED LINES ONLY — THIS IS CRITICAL:
 - You are reviewing a DIFF. Only flag issues on lines that were ADDED or MODIFIED

--- a/src/vigil/reviewer.py
+++ b/src/vigil/reviewer.py
@@ -69,6 +69,36 @@ def _parse_findings(raw_list: list[dict]) -> list[Finding]:
     return results
 
 
+_NO_ACTION_SUGGESTIONS = {
+    "n/a",
+    "none",
+    "no action needed",
+    "no change needed",
+    "no changes needed",
+    "not applicable",
+}
+
+
+def _parse_observations(raw_list: list[dict]) -> list[Finding]:
+    """Parse only observations that define concrete follow-up work.
+
+    Vigil turns observations into GitHub issues. Treat the LLM response as
+    untrusted at that boundary: praise, descriptions, and other notes without
+    a proposed action are review context, not backlog items.
+    """
+    observations = _parse_findings(raw_list)
+    actionable: list[Finding] = []
+
+    for observation in observations:
+        suggestion = (observation.suggestion or "").strip()
+        normalized = " ".join(suggestion.rstrip(".").lower().split())
+        if not suggestion or normalized in _NO_ACTION_SUGGESTIONS:
+            continue
+        actionable.append(observation)
+
+    return actionable
+
+
 def _gen_session_id() -> str:
     """Generate a short agent session ID like VGL-a3f8b2."""
     return f"VGL-{secrets.token_hex(3)}"
@@ -170,7 +200,7 @@ def _run_specialist(persona: Persona, pr_block: str, model: str, delay: float = 
     raw = _parse_json_response(content)
 
     findings = _parse_findings(raw.get("findings", []))
-    observations = _parse_findings(raw.get("observations", []))
+    observations = _parse_observations(raw.get("observations", []))
     checks = raw.get("checks", {})
     decision = raw.get("decision", "APPROVE")
 

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -11,6 +11,7 @@ from vigil.reviewer import (
     _is_transient_llm_error,
     _parse_findings,
     _parse_json_response,
+    _parse_observations,
     review_diff,
 )
 
@@ -59,6 +60,68 @@ class TestParseFindings:
                 "category": "test", "message": "msg"}]
         findings = _parse_findings(raw)
         assert findings[0].line is None
+
+
+# ---------- _parse_observations ----------
+
+class TestParseObservations:
+
+    def test_drops_praise_without_follow_up_action(self):
+        raw = [
+            {
+                "file": "src/components/Blog.tsx",
+                "line": 88,
+                "severity": "low",
+                "category": "documentation",
+                "message": "The comment regarding DOMPurify as 'defence in depth' is excellent context for future maintainers.",
+                "suggestion": None,
+            },
+            {
+                "file": "src/components/CDMOFailedRunReview.tsx",
+                "line": 641,
+                "severity": "low",
+                "category": "accessibility",
+                "message": "The addition of scroll-mt-28 to the error alert is a good fix for the fixed-navbar focus-scroll issue.",
+                "suggestion": None,
+            },
+        ]
+
+        assert _parse_observations(raw) == []
+
+    def test_keeps_observation_with_concrete_follow_up(self):
+        raw = [
+            {
+                "file": "src/components/Blog.tsx",
+                "line": 90,
+                "severity": "low",
+                "category": "security",
+                "message": "DOMPurify uses its default allowlist.",
+                "suggestion": "Define the permitted tags and attributes explicitly.",
+            }
+        ]
+
+        observations = _parse_observations(raw)
+
+        assert len(observations) == 1
+        assert observations[0].suggestion == "Define the permitted tags and attributes explicitly."
+
+    @pytest.mark.parametrize(
+        "suggestion",
+        [None, "", "   ", "N/A", "None.", "No action needed", "No changes needed."],
+    )
+    def test_drops_missing_or_no_op_suggestion(self, suggestion):
+        raw = [
+            {
+                "file": "a.py",
+                "line": 1,
+                "severity": "low",
+                "category": "documentation",
+                "message": "Informational note.",
+                "suggestion": suggestion,
+            }
+        ]
+
+        assert _parse_observations(raw) == []
 
 
 # ---------- _build_pr_context_block ----------


### PR DESCRIPTION
## Problem

Vigil converted two positive DX comments from F2iLLC/f2i-websites#81 into low-priority backlog issues:

- F2iLLC/f2i-websites#85 praised the DOMPurify defence-in-depth comment.
- F2iLLC/f2i-websites#86 praised the fixed-navbar focus-scroll fix.

Neither observation described a defect or requested a change, but both were posted as work that "should be tracked."

## Root cause

The specialist prompt already tells models not to emit compliments as observations. Gemini 3.1 Flash Lite nevertheless returned both compliments in `observations[]`, and the parser trusted every structurally valid observation. The posting pipeline then creates a GitHub issue for every aggregated observation.

## Fix

- Require every model-generated observation to include a concrete, non-null follow-up suggestion.
- Discard missing, blank, and explicit no-op suggestions at the LLM response boundary.
- Clarify the observation contract in the shared specialist schema.
- Preserve findings as-is; the stricter contract applies only to non-blocking observations that become backlog issues.

## Validation

- Added the exact #85 and #86 payloads as regression fixtures.
- Added coverage for actionable suggestions and common no-op placeholders.
- `PYTHONPATH=src python -m pytest -q` — 460 passed.
- `python -m ruff check src/vigil/personas.py src/vigil/reviewer.py` — passed.
