### PR TITLE
chore: pin reusable workflow to resolve-addressed fix

### DIFF
--- a/.github/workflows/reusable-vigil.yml
+++ b/.github/workflows/reusable-vigil.yml
@@ -129,7 +129,7 @@ jobs:
 
       # Pin the composite action independently from this reusable workflow.
       # Update this one reference when a reviewed Vigil implementation lands.
-      - uses: F2iLLC/vigil@fd918eb1d2dbaa16cbecc424aa17ba23002e6685
+      - uses: F2iLLC/vigil@0571cd6668c320264f5041d4603675dc88850ad5
         if: steps.provider.outputs.has_key == 'true'
         continue-on-error: ${{ inputs.advisory }}
         with:
@@ -174,7 +174,7 @@ jobs:
         run: |
           echo "url=${{ github.event.pull_request.html_url || github.event.issue.pull_request.html_url }}" >> "$GITHUB_OUTPUT"
 
-      - uses: F2iLLC/vigil@fd918eb1d2dbaa16cbecc424aa17ba23002e6685
+      - uses: F2iLLC/vigil@0571cd6668c320264f5041d4603675dc88850ad5
         continue-on-error: ${{ inputs.advisory }}
         with:
           pr-url: ${{ steps.pr.outputs.url }}
@@ -191,7 +191,7 @@ jobs:
       github.event.action == 'synchronize' &&
       github.event.pull_request.draft == false
     steps:
-      - uses: F2iLLC/vigil@fd918eb1d2dbaa16cbecc424aa17ba23002e6685
+      - uses: F2iLLC/vigil@0571cd6668c320264f5041d4603675dc88850ad5
         continue-on-error: ${{ inputs.advisory }}
         with:
           command: resolve-addressed

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ python -m pip install -e ".[webhook]"
 For a pinned CLI installation without cloning:
 
 ```bash
-python -m pip install "git+https://github.com/F2iLLC/vigil.git@fd918eb1d2dbaa16cbecc424aa17ba23002e6685"
+python -m pip install "git+https://github.com/F2iLLC/vigil.git@0571cd6668c320264f5041d4603675dc88850ad5"
 ```
 
 ## Quick start
@@ -279,7 +279,7 @@ Repository secrets are not exposed to untrusted fork pull requests under the nor
 If the centralized lifecycle is unnecessary, call the composite action directly:
 
 ```yaml
-- uses: F2iLLC/vigil@fd918eb1d2dbaa16cbecc424aa17ba23002e6685
+- uses: F2iLLC/vigil@0571cd6668c320264f5041d4603675dc88850ad5
   with:
     model: gemini/gemini-3.1-flash-lite
     profile: default


### PR DESCRIPTION
## Summary
- update the reusable workflow's pinned composite action SHA to the reviewed #41 merge commit
- update README pinned install/action examples to the same SHA

## Why
#41 fixed `resolve-addressed` for replied same-file review threads, but the reusable workflow pins `F2iLLC/vigil@...` independently. This updates that deployment pin so downstream repositories using the reusable workflow pick up the reviewed fix.

## Verification
- `rg -n fd918eb1d2dbaa16cbecc424aa17ba23002e6685|0571cd6668c320264f5041d4603675dc88850ad5 .github\\workflows README.md -S`
- `git diff --check`