### PR TITLE
Fix disposition handling before skip

### DIFF
--- a/.github/workflows/reusable-vigil.yml
+++ b/.github/workflows/reusable-vigil.yml
@@ -156,7 +156,19 @@ jobs:
           contains(github.event.comment.body, 'addressed') ||
           contains(github.event.comment.body, 'Addressed') ||
           contains(github.event.comment.body, 'done') ||
-          contains(github.event.comment.body, 'Done')
+          contains(github.event.comment.body, 'Done') ||
+          contains(github.event.comment.body, 'overruled') ||
+          contains(github.event.comment.body, 'Overruled') ||
+          contains(github.event.comment.body, 'over ruled') ||
+          contains(github.event.comment.body, 'Over ruled') ||
+          contains(github.event.comment.body, 'wontfix') ||
+          contains(github.event.comment.body, 'acceptable') ||
+          contains(github.event.comment.body, 'follow-up') ||
+          contains(github.event.comment.body, 'follow up') ||
+          contains(github.event.comment.body, 'tracked') ||
+          contains(github.event.comment.body, '#') ||
+          contains(github.event.comment.body, '/issues/') ||
+          contains(github.event.comment.body, '/pull/')
         )
       ) || (
         github.event_name == 'issue_comment' &&
@@ -164,7 +176,25 @@ jobs:
         !contains(github.event.comment.body, '/vigil review') &&
         (
           contains(github.event.comment.body, 'resolved') ||
-          contains(github.event.comment.body, 'Resolved')
+          contains(github.event.comment.body, 'Resolved') ||
+          contains(github.event.comment.body, 'fixed') ||
+          contains(github.event.comment.body, 'Fixed') ||
+          contains(github.event.comment.body, 'addressed') ||
+          contains(github.event.comment.body, 'Addressed') ||
+          contains(github.event.comment.body, 'done') ||
+          contains(github.event.comment.body, 'Done') ||
+          contains(github.event.comment.body, 'overruled') ||
+          contains(github.event.comment.body, 'Overruled') ||
+          contains(github.event.comment.body, 'over ruled') ||
+          contains(github.event.comment.body, 'Over ruled') ||
+          contains(github.event.comment.body, 'wontfix') ||
+          contains(github.event.comment.body, 'acceptable') ||
+          contains(github.event.comment.body, 'follow-up') ||
+          contains(github.event.comment.body, 'follow up') ||
+          contains(github.event.comment.body, 'tracked') ||
+          contains(github.event.comment.body, '#') ||
+          contains(github.event.comment.body, '/issues/') ||
+          contains(github.event.comment.body, '/pull/')
         )
       )
     steps:

--- a/src/vigil/cli.py
+++ b/src/vigil/cli.py
@@ -362,6 +362,10 @@ def resolve_addressed(
 
     console.print(f"[dim]Last Vigil review at {last_sha[:7]}, head is {pr_data['head_sha'][:7]}[/dim]")
 
+    dismissed = resolve_dismissed_threads(owner, repo, pr_number, token)
+    if dismissed:
+        console.print(f"[dim]Resolved {dismissed} dismissed thread(s)[/dim]")
+
     if last_sha == pr_data["head_sha"]:
         console.print("[dim]No new commits since last review — nothing to resolve[/dim]")
         raise typer.Exit(0)
@@ -388,12 +392,6 @@ def resolve_addressed(
 
     count = resolve_addressed_threads(owner, repo, pr_number, token, changed_line_map)
     console.print(f"[dim]Auto-resolved {count} addressed thread(s)[/dim]")
-
-    # Also dismiss any threads with "resolved" replies while we're at it
-    dismissed = resolve_dismissed_threads(owner, repo, pr_number, token)
-    if dismissed:
-        console.print(f"[dim]Also resolved {dismissed} dismissed thread(s)[/dim]")
-
 
 @app.command()
 def serve(

--- a/src/vigil/comment_manager.py
+++ b/src/vigil/comment_manager.py
@@ -21,10 +21,11 @@ VIGIL_SESSION_PATTERN = re.compile(r"VGL-[0-9a-f]{6}")
 
 # Resolution reply detection
 _RESOLUTION_KEYWORDS = re.compile(
-    r"\b(resolved|fixed|addressed|done)\b", re.IGNORECASE
+    r"\b(resolved|fixed|addressed|done|over\s*ruled|overridden|wontfix|acceptable|follow[-\s]?up|tracked)\b",
+    re.IGNORECASE,
 )
-_ISSUE_LINK_PATTERN = re.compile(
-    r"https?://github\.com/([^/]+)/([^/]+)/issues/(\d+)"
+_TRACKING_LINK_PATTERN = re.compile(
+    r"https?://github\.com/([^/]+)/([^/]+)/(?:issues|pull)/(\d+)"
 )
 _SHORT_ISSUE_REF = re.compile(r"#(\d+)")
 _ISSUE_RELEVANCE_THRESHOLD = 0.25
@@ -376,7 +377,7 @@ def _is_resolution_reply(body: str) -> bool:
     if _RESOLUTION_KEYWORDS.search(body):
         return True
     # Issue link (full URL or short ref like #45)
-    if _ISSUE_LINK_PATTERN.search(body) or _SHORT_ISSUE_REF.search(body):
+    if _TRACKING_LINK_PATTERN.search(body) or _SHORT_ISSUE_REF.search(body):
         return True
     return False
 
@@ -392,7 +393,7 @@ def _extract_issue_refs(body: str) -> list[tuple[str, str, int]]:
 
     # Full URL matches — track their spans so we don't double-count short refs inside them
     full_url_spans: list[tuple[int, int]] = []
-    for match in _ISSUE_LINK_PATTERN.finditer(body):
+    for match in _TRACKING_LINK_PATTERN.finditer(body):
         owner, repo, num = match.group(1), match.group(2), int(match.group(3))
         results.append((owner, repo, num))
         full_url_spans.append((match.start(), match.end()))
@@ -583,7 +584,13 @@ def resolve_dismissed_threads(
                 # Infer decision type from the reply text
                 reason = info.get("reason", "")
                 reason_lower = reason.lower()
-                if "false positive" in reason_lower or "false_positive" in reason_lower:
+                if (
+                    "false positive" in reason_lower
+                    or "false_positive" in reason_lower
+                    or "overruled" in reason_lower
+                    or "over ruled" in reason_lower
+                    or "overridden" in reason_lower
+                ):
                     decision_type = "false_positive"
                 elif "wontfix" in reason_lower or "won't fix" in reason_lower or "acceptable" in reason_lower:
                     decision_type = "wontfix"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,33 @@
+import pytest
+import typer
+
+from vigil import cli
+
+
+def test_resolve_addressed_checks_dismissed_threads_before_unchanged_head_skip(monkeypatch):
+    calls: list[str] = []
+
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(cli, "parse_pr_url", lambda pr_url: ("F2iLLC", "demo", 1))
+    monkeypatch.setattr(
+        cli,
+        "get_pr_data",
+        lambda *args: {"head_sha": "same-sha", "diff": ""},
+    )
+    monkeypatch.setattr(cli, "get_last_reviewed_sha", lambda *args: "same-sha")
+
+    def fake_resolve_dismissed_threads(*args):
+        calls.append("dismissed")
+        return 1
+
+    def fail_if_compared(*args):
+        raise AssertionError("unchanged heads should not compare commits")
+
+    monkeypatch.setattr(cli, "resolve_dismissed_threads", fake_resolve_dismissed_threads)
+    monkeypatch.setattr(cli, "get_changed_files_between_commits", fail_if_compared)
+
+    with pytest.raises(typer.Exit) as exc:
+        cli.resolve_addressed("https://github.com/F2iLLC/demo/pull/1")
+
+    assert exc.value.exit_code == 0
+    assert calls == ["dismissed"]

--- a/tests/test_comment_manager.py
+++ b/tests/test_comment_manager.py
@@ -397,6 +397,12 @@ class TestIsResolutionReply:
     def test_resolved_with_issue_link(self):
         assert _is_resolution_reply("Resolved via https://github.com/o/r/issues/10") is True
 
+    def test_overruled_reply(self):
+        assert _is_resolution_reply("Overruled by maintainer; acceptable risk.") is True
+
+    def test_follow_up_reply(self):
+        assert _is_resolution_reply("Tracked for a follow-up PR.") is True
+
     def test_just_number_not_resolution(self):
         assert _is_resolution_reply("42") is False
 
@@ -409,6 +415,11 @@ class TestExtractIssueRefs:
         refs = _extract_issue_refs("See https://github.com/org/repo/issues/123")
         assert len(refs) == 1
         assert refs[0] == ("org", "repo", 123)
+
+    def test_full_pull_url(self):
+        refs = _extract_issue_refs("Follow-up PR: https://github.com/org/repo/pull/456")
+        assert len(refs) == 1
+        assert refs[0] == ("org", "repo", 456)
 
     def test_short_ref(self):
         refs = _extract_issue_refs("Fixed in #45")


### PR DESCRIPTION
Closes #42

## Summary
- run dismissed/dispositioned-thread handling before `resolve-addressed` exits on unchanged heads
- recognize more explicit disposition replies: overruled/acceptable/wontfix/follow-up/tracked
- treat full GitHub PR links like issue links when verifying follow-up tracking
- broaden the reusable workflow dismissal trigger so those replies wake the resolver without requiring a new commit

## Verification
- `$env:PYTHONPATH='src'; python -m pytest tests\test_comment_manager.py tests\test_cli.py` (81 passed)
- `$env:PYTHONPATH='src'; python -m pytest` (473 passed)
- `git diff --check`