### PR TITLE
test: pin pytest asyncio fixture loop scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/vigil"]
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
## Summary
- Set `asyncio_default_fixture_loop_scope = "function"` in pytest config.
- Aligns the test runner with pytest-asyncio's stated future default and removes the deprecation warning seen during the full suite.

## Why
Current Vigil main passes tests, but pytest-asyncio 1.3.0 emits a deprecation warning because the default async fixture loop scope is unset. Pinning it explicitly keeps future pytest-asyncio upgrades from changing behavior silently and keeps the test output quieter.

## Validation
- `PYTHONPATH=src python -m pytest` - 473 passed, no pytest-asyncio default fixture loop scope warning; pytest header reports `asyncio_default_fixture_loop_scope=function`
- `git diff --check` - clean apart from the existing Windows LF-to-CRLF working-copy warning
