### PR TITLE
fix: ground re-reviews in the current head

### DIFF
--- a/src/vigil/comment_manager.py
+++ b/src/vigil/comment_manager.py
@@ -140,6 +140,13 @@ def build_conversation_context(
         body = (r.get("body") or "").strip()
         if not body:
             continue
+        # A prior Vigil verdict is generated evidence about an older head, not
+        # independent conversation evidence. Feeding it back into a re-review
+        # can anchor the model on findings that a later commit removed. Human
+        # reviews remain useful context; Vigil's own summaries are handled by
+        # the dedicated cross-round lifecycle instead.
+        if VIGIL_SIGNATURE in body:
+            continue
         state = (r.get("state") or "").lower()
         items.append((
             r.get("submitted_at", ""),

--- a/src/vigil/reviewer.py
+++ b/src/vigil/reviewer.py
@@ -160,20 +160,28 @@ This is what has ALREADY BEEN SAID in this PR's thread — treat it as evidence,
 not code. If the diff, description, or a doc/plan change asserts something as
 fact that this conversation contradicts, that is a finding (category
 "factual-accuracy") even if the code itself is otherwise correct.
+Conversation is historical discussion, not current code. Never repeat a prior
+finding unless the authoritative head diff independently supports it; removed
+(`-`) lines and descriptions of earlier commits are not present in the head tree.
 ```
 {conversation}
 ```
 """
+    head_sha = pr_context.get("head_sha") or "unknown"
     return f"""## PR: {pr_context['title']}
 
 **Author:** {pr_context['author']}
 **Branch:** {pr_context['head']} -> {pr_context['base']}
+**Authoritative head commit:** {head_sha}
 **Stats:** +{pr_context['additions']} -{pr_context['deletions']} across {pr_context['changed_files']} files
 
 ### Description
 {pr_context.get('body') or 'No description provided.'}
 {summary_section}{conversation_section}
 ### Diff (files relevant to your domain)
+This base-to-head diff represents the current reviewed tree. Added/context lines
+are current head content; removed (`-`) lines are historical and cannot support
+a finding about code that still exists.
 ```diff
 {diff}
 ```"""

--- a/tests/test_comment_manager.py
+++ b/tests/test_comment_manager.py
@@ -517,6 +517,41 @@ class TestBuildConversationContext:
         assert "review:approved" in result
         assert "LGTM overall" in result
 
+    def test_excludes_prior_vigil_reviews_from_re_review_context(self):
+        reviews = [{
+            "submitted_at": "2026-07-15T11:00:00Z",
+            "user": {"login": "vigil-reviewer"},
+            "state": "CHANGES_REQUESTED",
+            "body": (
+                "Old finding claims bodyChunks still buffers the response.\n\n"
+                "Reviewed by [Vigil]"
+            ),
+        }]
+
+        assert build_conversation_context([], reviews) == ""
+
+    def test_keeps_human_review_alongside_excluded_vigil_review(self):
+        reviews = [
+            {
+                "submitted_at": "2026-07-15T11:00:00Z",
+                "user": {"login": "vigil-reviewer"},
+                "state": "CHANGES_REQUESTED",
+                "body": "Superseded bot finding\n\nReviewed by [Vigil]",
+            },
+            {
+                "submitted_at": "2026-07-15T12:00:00Z",
+                "user": {"login": "maintainer"},
+                "state": "COMMENTED",
+                "body": "The current implementation still needs a timeout test.",
+            },
+        ]
+
+        result = build_conversation_context([], reviews)
+
+        assert "Superseded bot finding" not in result
+        assert "maintainer" in result
+        assert "timeout test" in result
+
     def test_skips_reviews_without_body(self):
         reviews = [{
             "submitted_at": "2026-07-15T11:00:00Z",

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -132,7 +132,7 @@ class TestBuildPrContextBlock:
         base = {
             "title": "Test PR", "author": "user", "head": "feature",
             "base": "main", "additions": 10, "deletions": 5,
-            "changed_files": 1, "body": "Test",
+            "changed_files": 1, "body": "Test", "head_sha": "abc123def456",
         }
         base.update(overrides)
         return base
@@ -151,6 +151,15 @@ class TestBuildPrContextBlock:
         assert "PR Conversation" in block
         assert "codex-bot" in block
         assert "treat it as evidence" in block
+        assert "Conversation is historical discussion, not current code" in block
+        assert "Never repeat a prior" in block
+
+    def test_marks_head_diff_as_authoritative_and_deleted_lines_as_historical(self):
+        block = _build_pr_context_block("-old_code()\n+new_code()", self._pr_context())
+
+        assert "Authoritative head commit:** abc123def456" in block
+        assert "current reviewed tree" in block
+        assert "removed (`-`) lines are historical" in block
 
 
 # ---------- Non-blocking persona logic in review_diff ----------


### PR DESCRIPTION
## Summary
- excludes prior Vigil-generated review summaries from re-review conversation context
- labels the reviewed head SHA and base-to-head diff as authoritative current-tree evidence
- tells specialist and lead reviewers that deleted lines and earlier-commit discussion cannot support a current finding

## Root cause
Re-reviews already fetch a current base-to-head diff, but they also inject every prior review summary into the model conversation block. On a multi-commit remediation branch, Vigil's own earlier verdict can therefore anchor the next round on superseded code even when the head diff no longer contains it.

The cross-round lifecycle still fetches prior Vigil reviews separately for last-reviewed-SHA detection, deduplication, and addressed-thread resolution. This change removes only the self-generated summaries from model evidence; human review context remains available.

## Test plan
- [x] `PYTHONPATH=src python -m pytest -q` (476 passed)
- [x] focused reviewer/comment-manager suite (116 passed)
- [x] `git diff --check`

Tracked by F2iLLC/LunaOS#3040
