### PR TITLE
fix: Detect Python guard now probes venv, not just version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **`find_best_file_for_finding` fallback** — Now correctly skips files with empty line sets when falling back to the first alphabetical file.
 - **`_mock_response` helper** — Fixed falsy `{}` bug where `json_data or []` treated empty dict as falsy.
+- **`Detect Python` guard now probes `venv`, not just version** — The guard previously checked only that system `python3` was >= 3.10 before skipping `actions/setup-python`. On Debian/Ubuntu, a 3.10+ interpreter can still lack `ensurepip` (the `python3.X-venv` package is separate), so `python3 -m venv` failed downstream even though the guard reported success — and `actions/setup-python` was skipped exactly when it was needed. Now runs `python3 -m venv` against a throwaway directory as part of the check and falls back to `actions/setup-python` if it fails. Root cause of F2iLLC/LunaOS#3775 (fleet-wide: also hit bioqms-core, relara, praxislms via the same `lunaos-light-1` runner).
 
 ## [0.1.0] - 2026-03-12
 

--- a/action.yml
+++ b/action.yml
@@ -55,10 +55,26 @@ runs:
         if command -v python3 >/dev/null 2>&1; then
           PY_VERSION="$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
           if python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)'; then
-            echo "Found system python3 $PY_VERSION — skipping setup-python"
-            echo "python=$(command -v python3)" >> "$GITHUB_OUTPUT"
-            echo "needs_setup=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            # A version check alone is not sufficient: Debian/Ubuntu ships
+            # python3 without ensurepip unless python3.X-venv is separately
+            # installed, so `python3 -m venv` can fail even though the
+            # interpreter itself is a perfectly fine 3.10+. Probe that venv
+            # actually works before committing to the system interpreter —
+            # otherwise this guard reports success, "Install Vigil into a
+            # venv" then hard-fails, and (depending on the caller's
+            # continue-on-error setting) the whole run can silently report
+            # green without ever posting a review. Seen for real on
+            # F2iLLC/LunaOS's lunaos-light-1 runner (LunaOS#3775).
+            PROBE_DIR="$(mktemp -d)"
+            if python3 -m venv "$PROBE_DIR/probe" >/dev/null 2>&1; then
+              rm -rf "$PROBE_DIR"
+              echo "Found system python3 $PY_VERSION with a working venv module — skipping setup-python"
+              echo "python=$(command -v python3)" >> "$GITHUB_OUTPUT"
+              echo "needs_setup=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            rm -rf "$PROBE_DIR"
+            echo "System python3 $PY_VERSION found, but 'python3 -m venv' failed (ensurepip missing?) — falling back to setup-python"
           fi
         fi
         echo "No suitable system python3 — will run actions/setup-python"


### PR DESCRIPTION
## Summary

Root-cause fix for F2iLLC/LunaOS#3775 ("Vigil review action fails to
install on lunaos-light-1, review check reports SUCCESS regardless").

The composite action's `Detect Python` step decides whether to skip
`actions/setup-python` based only on the system `python3`'s version
(`>= 3.10`). On Debian/Ubuntu, a 3.10+ interpreter can still be
missing `ensurepip` — `python3.X-venv` is a separate `apt` package —
so `python3 -m venv` in the next step ("Install Vigil into a venv")
fails even though the version guard passed. `actions/setup-python`
gets skipped exactly when it was needed, because the guard never
tested the thing that actually matters (whether `venv` works), only a
proxy for it (the version number).

This is exactly what's been happening on `lunaos-light-1` since
~2026-08-03 21:48 UTC — confirmed from the run logs
(`##[error]Process completed with exit code 1` /
`The virtual environment was not created successfully because
ensurepip is not available.`) — and it's fleet-wide: the same runner
backs `ci-light` for LunaOS, bioqms-core, relara, and praxislms, so
every one of those repos has been silently getting zero real reviews
since the break.

## Fix

`Detect Python` now probes `python3 -m venv` against a throwaway
`mktemp -d` directory as part of the guard, in addition to the
version check. If the probe fails, it falls through to
`actions/setup-python` (3.12 from the GitHub Actions toolcache, which
does ship `ensurepip`) instead of reporting a false "needs_setup=false".

## What this does NOT fix

- The underlying package gap on `lunaos-light-1` itself
  (`apt install python3.12-venv` — needs root on that host, which no
  agent working #3775 had).
- Whether `actions/setup-python` can actually download a Python
  distribution on `lunaos-light-1`'s restricted egress (it's a
  "low-spec box reserved for light API-bound jobs" per the LunaOS
  workflow's own comments) — that's the existing, previously-untested
  fallback path for this exact scenario, not something new I can
  verify from here. If it also can't reach the toolcache, `needs_setup`
  will still correctly report the failure now instead of silently
  reporting success, which is strictly better than today even in that
  case.
- The **companion** bug where callers wrap this action in
  `continue-on-error: true` and therefore report a green check even
  when this action's own steps fail — that's fixed separately, per
  caller, e.g. F2iLLC/LunaOS#3806.

## Test plan

- [x] `action.yml` YAML validated with `yaml.safe_load`
- [x] Tested the new probe logic locally (extracted to a standalone
      bash script) against:
  - the real system Python here (3.14, working venv) →
    `needs_setup=false`, as before
  - a stub `python3` that passes the version check but fails
    `python3 -m venv` (reproducing the literal `ensurepip` error text
    from the `lunaos-light-1` logs) → correctly falls through to
    `needs_setup=true`
- [ ] Once merged and the `v1` tag is moved (or a new minor tag cut),
      confirm a live run on `lunaos-light-1` either succeeds via
      `actions/setup-python` or fails with an accurate (non-swallowed)
      status

Ref F2iLLC/LunaOS#3775.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01UtvVYRF2zBHyZXdftGNHJ4