### PR TITLE
fix(review): #49 #48 reach re-review on an unchanged head and withdraw superseded blocks

### DIFF
--- a/.github/workflows/reusable-vigil.yml
+++ b/.github/workflows/reusable-vigil.yml
@@ -72,9 +72,17 @@ jobs:
         shell: bash
         run: |
           if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            # Reaching this job on an issue_comment means the job-level `if:`
+            # already matched '/vigil review', so this is an explicit on-demand
+            # request. Forward that as --force: without it the run short-circuits
+            # on an unchanged head and posts nothing (F2iLLC/vigil#49).
             echo "url=${{ github.event.issue.pull_request.html_url }}" >> "$GITHUB_OUTPUT"
+            echo "force=true" >> "$GITHUB_OUTPUT"
+            echo "reason=on-demand /vigil review comment" >> "$GITHUB_OUTPUT"
           else
             echo "url=${{ github.event.pull_request.html_url }}" >> "$GITHUB_OUTPUT"
+            echo "force=false" >> "$GITHUB_OUTPUT"
+            echo "reason=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check review provider key
@@ -129,11 +137,19 @@ jobs:
 
       # Pin the composite action independently from this reusable workflow.
       # Update this one reference when a reviewed Vigil implementation lands.
+      #
+      # NOTE: the `force` and `reason` inputs below were added alongside
+      # F2iLLC/vigil#49 and do not exist at the pinned SHA. GitHub treats
+      # unknown composite-action inputs as a warning, not an error, so this is
+      # safe — but the on-demand '/vigil review' fix stays INERT until this pin
+      # is advanced to a commit that contains them.
       - uses: F2iLLC/vigil@0571cd6668c320264f5041d4603675dc88850ad5
         if: steps.provider.outputs.has_key == 'true'
         continue-on-error: ${{ inputs.advisory }}
         with:
           pr-url: ${{ steps.pr.outputs.url }}
+          force: ${{ steps.pr.outputs.force }}
+          reason: ${{ steps.pr.outputs.reason }}
           model: ${{ inputs.model }}
           lead-model: ${{ inputs.lead-model }}
           profile: ${{ inputs.profile }}

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Options:
   -p, --profile TEXT    default or enterprise
   --json                Print the structured result
   --post                Post the result to GitHub
+  --force               Review even when no files changed since the last review
+  --reason TEXT         Why the review was requested (recorded in the run log)
 ```
 
 Examples:
@@ -161,14 +163,43 @@ vigil serve \
 
 Vigil reviews the full PR diff against the base branch. On a posted re-review it also:
 
-1. Locates the most recent Vigil review commit.
+1. Locates the most recent Vigil review commit, and the **state** of Vigil's reviews.
 2. Resolves threads with accepted resolution replies.
-3. Checks whether the PR head changed; if no files changed, it skips the duplicate review.
+3. Checks whether the PR head changed; if no files changed, it skips the duplicate review — unless one of the re-review triggers below applies.
 4. Resolves threads whose cited code changed.
 5. Re-reviews the **full PR diff**, not only the latest commit or changed-file subset.
 6. Filters findings already covered by active or resolved Vigil comments.
 
 This distinction matters: incremental state controls skipping, thread resolution, and deduplication, while the model still receives the complete PR change.
+
+### Re-review triggers on an unchanged head
+
+Skipping on an unchanged head keeps re-review cost down, but a PR must never be
+able to reach a state it cannot leave. Vigil therefore still reviews — against
+the full base-to-head diff — when any of the following hold:
+
+- the run was explicitly requested with `/vigil review`;
+- a Vigil `CHANGES_REQUESTED` review is still standing, so the block can be reconsidered;
+- the current head carries no live Vigil verdict, for example because the verdict at head was dismissed;
+- Vigil threads were resolved during this run, so the evidence behind the prior verdict changed.
+
+Liveness is evaluated on each review's `state`, not on recency: `dismiss_stale_reviews_on_push`
+leaves `DISMISSED` reviews in the API response, and a dismissed review must not read as a live one.
+
+No empty or no-op commit is ever required to obtain a fresh verdict.
+
+### Withdrawing a superseded block
+
+When a re-review concludes **APPROVE**, Vigil dismisses its own prior
+`CHANGES_REQUESTED` reviews, naming the head SHA that satisfied them. This
+matters because `dismiss_stale_reviews_on_push` only stale-dismisses
+*approvals*: without an explicit withdrawal, a later push drops Vigil's
+approval and an older block becomes the latest live review again.
+
+A re-review that still concludes `REQUEST_CHANGES` changes nothing — Vigil
+standing its ground is intended. Nothing is dismissed when the review degraded
+to a `COMMENT` event, because a comment clears no block and dismissing the old
+one would leave the PR unguarded.
 
 ### Documentation-only PRs
 
@@ -296,6 +327,8 @@ Available inputs:
 | `model` | `gemini/gemini-3.1-flash-lite` | LiteLLM model identifier |
 | `lead-model` | Same as `model` | Optional separate lead model |
 | `profile` | `default` | `default` or `enterprise` |
+| `force` | `false` | Review even when no files changed since the last review; the reusable workflow sets this for on-demand `/vigil review` |
+| `reason` | Empty | Why the review was requested; recorded in the run log |
 | `github-token` | `github.token` | Use `VIGIL_REVIEW_TOKEN` for real approval events |
 | `gemini-api-key` | Empty | Gemini provider credential |
 | `anthropic-api-key` | Empty | Anthropic provider credential |

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,14 @@ inputs:
     description: "Review profile: default, enterprise"
     required: false
     default: "default"
+  force:
+    description: "Review even when no files changed since the last review (set for on-demand '/vigil review')"
+    required: false
+    default: "false"
+  reason:
+    description: "Why this review was requested; recorded in the run log"
+    required: false
+    default: ""
   github-token:
     description: "GitHub token for posting reviews (defaults to GITHUB_TOKEN)"
     required: false
@@ -110,6 +118,11 @@ runs:
         GEMINI_API_KEY: ${{ inputs.gemini-api-key }}
         OPENAI_API_KEY: ${{ inputs.openai-api-key }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+        # Passed via env rather than interpolated into the script body: the
+        # reason can carry caller-supplied text, and `${{ }}` inside `run:` is
+        # a shell-injection surface.
+        VIGIL_FORCE: ${{ inputs.force }}
+        VIGIL_REASON: ${{ inputs.reason }}
       run: |
         set -euo pipefail
         VIGIL="${{ steps.install.outputs.vigil }}"
@@ -133,6 +146,15 @@ runs:
           )
           if [ -n "${{ inputs.lead-model }}" ]; then
             ARGS+=(--lead-model "${{ inputs.lead-model }}")
+          fi
+          # An on-demand '/vigil review' must produce a fresh verdict even when
+          # the head has not moved, otherwise the documented escape hatch is a
+          # no-op on exactly the PRs that need it (F2iLLC/vigil#49).
+          if [ "${VIGIL_FORCE:-false}" = "true" ]; then
+            ARGS+=(--force)
+          fi
+          if [ -n "${VIGIL_REASON:-}" ]; then
+            ARGS+=(--reason "$VIGIL_REASON")
           fi
           "$VIGIL" review "${ARGS[@]}"
         fi

--- a/src/vigil/cli.py
+++ b/src/vigil/cli.py
@@ -12,11 +12,13 @@ from rich.table import Table
 from .audit import write_audit_entry
 from .comment_manager import (
     build_conversation_context,
+    dismiss_stale_vigil_blocks,
     fetch_all_pr_reviews,
     fetch_all_vigil_comments,
     fetch_pr_conversation_comments,
     fetch_vigil_comments,
     get_last_reviewed_sha,
+    get_vigil_review_state,
     resolve_addressed_threads,
     resolve_dismissed_threads,
 )
@@ -92,6 +94,46 @@ def _print_findings(findings: list[Finding], title: str):
             console.print(f"  [dim]{loc}[/dim] -> {f.suggestion}")
 
 
+def _rereview_reasons(
+    *,
+    forced: bool,
+    reason: str,
+    outstanding_blocks: list[dict],
+    settled_verdict_at_head: bool,
+    resolved_threads: int,
+) -> list[str]:
+    """Why a review should run even though no files changed since last review.
+
+    Pure, so the gate can be tested without a network. An empty list means the
+    ordinary case — no new commits, no standing block, nobody asked — and the
+    caller must keep short-circuiting. That short-circuit is what keeps
+    re-review cost down across the fleet; do not weaken it (issue #49).
+
+    The three exits, and the real incidents each one covers:
+
+    1. ``forced`` — an on-demand ``/vigil review``. The documented escape
+       hatch routed through the same skip and was a no-op (praxislms#263).
+    2. a standing block, or no settled verdict on the current head. These are
+       two shapes of the same deadlock: bioqms-core#1472 left a live
+       CHANGES_REQUESTED at head, praxislms#263 had that same verdict
+       *dismissed* at head. Keying only on "an outstanding CHANGES_REQUESTED
+       exists" would have missed the second; keying only on "no live review at
+       head" would have missed the first. Both are checked.
+    3. ``resolved_threads`` — Vigil threads were resolved during this run, so
+       the evidence the prior verdict rested on has changed.
+    """
+    reasons: list[str] = []
+    if forced:
+        reasons.append(f"explicitly requested ({reason})" if reason else "explicitly requested")
+    if outstanding_blocks:
+        reasons.append(f"{len(outstanding_blocks)} outstanding Vigil block(s) to reconsider")
+    if not settled_verdict_at_head:
+        reasons.append("no live Vigil verdict on the current head")
+    if resolved_threads:
+        reasons.append(f"{resolved_threads} Vigil thread(s) resolved since the last review")
+    return reasons
+
+
 @app.command()
 def review(
     pr_url: str = typer.Argument(help="GitHub PR URL"),
@@ -100,6 +142,14 @@ def review(
     profile: str = typer.Option("default", "--profile", "-p", help="Review profile: default, enterprise"),
     output_json: bool = typer.Option(False, "--json", help="Output raw JSON result"),
     post: bool = typer.Option(False, "--post", help="Post review as GitHub PR comment"),
+    force: bool = typer.Option(
+        False, "--force",
+        help="Review even when no files changed since the last review (on-demand '/vigil review')",
+    ),
+    reason: str = typer.Option(
+        "", "--reason",
+        help="Why this review was requested; recorded in the run log",
+    ),
 ):
     """Review a GitHub pull request with multi-persona specialist team."""
     # Validate profile
@@ -147,12 +197,21 @@ def review(
 
     # --- Pre-review pipeline: incremental review, resolve, dedup ---
     last_sha = None
+    outstanding_blocks: list[dict] = []
+    settled_verdict_at_head = True
     existing_comments: list[dict] = []
     review_diff_text = pr_data["diff"]
 
     if post:
         try:
-            last_sha = get_last_reviewed_sha(owner, repo, pr_number, token)
+            # Sibling of get_last_reviewed_sha that keeps the review *state*
+            # the SHA alone collapses away (issue #49). One fetch, not two.
+            review_state = get_vigil_review_state(
+                owner, repo, pr_number, token, pr_data["head_sha"],
+            )
+            last_sha = review_state.last_reviewed_sha
+            outstanding_blocks = review_state.outstanding_blocks
+            settled_verdict_at_head = review_state.settled_verdict_at_head
         except Exception as e:
             console.print(f"[dim yellow]Could not check previous reviews: {e}[/dim yellow]")
 
@@ -160,6 +219,7 @@ def review(
         console.print(f"[dim]Previous review at commit {last_sha[:7]}[/dim]")
 
         # Resolve threads with "resolved" replies
+        dismissed = 0
         try:
             dismissed = resolve_dismissed_threads(owner, repo, pr_number, token)
             if dismissed:
@@ -173,26 +233,43 @@ def review(
                 owner, repo, last_sha, pr_data["head_sha"], token,
             )
             if not changed_files:
-                console.print("[dim]No files changed since last review — skipping[/dim]")
-                raise typer.Exit(0)
+                # No new commits. Ordinarily that means there is nothing to say
+                # and skipping is correct — but a PR can be sitting on a verdict
+                # only a fresh review can clear, and until this gate existed
+                # there was no way back in (issue #49).
+                reasons = _rereview_reasons(
+                    forced=force,
+                    reason=reason,
+                    outstanding_blocks=outstanding_blocks,
+                    settled_verdict_at_head=settled_verdict_at_head,
+                    resolved_threads=dismissed,
+                )
+                if not reasons:
+                    console.print("[dim]No files changed since last review — skipping[/dim]")
+                    raise typer.Exit(0)
+                console.print(
+                    "[dim]No files changed since last review, but re-reviewing: "
+                    f"{'; '.join(reasons)}[/dim]"
+                )
+            else:
+                console.print(f"[dim]Incremental review: {len(changed_files)} file(s) changed since {last_sha[:7]}[/dim]")
 
-            console.print(f"[dim]Incremental review: {len(changed_files)} file(s) changed since {last_sha[:7]}[/dim]")
-
-            # Auto-resolve threads at changed lines
-            # Build line map ONLY for changed files (to auto-resolve outdated threads)
-            incremental_lines = commentable_lines(pr_data["diff"])
-            changed_set = set(changed_files)
-            changed_line_map = {f: lines for f, lines in incremental_lines.items() if f in changed_set}
-            resolved = resolve_addressed_threads(
-                owner, repo, pr_number, token, changed_line_map,
-            )
-            if resolved:
-                console.print(f"[dim]Auto-resolved {resolved} outdated thread(s)[/dim]")
+                # Auto-resolve threads at changed lines
+                # Build line map ONLY for changed files (to auto-resolve outdated threads)
+                incremental_lines = commentable_lines(pr_data["diff"])
+                changed_set = set(changed_files)
+                changed_line_map = {f: lines for f, lines in incremental_lines.items() if f in changed_set}
+                resolved = resolve_addressed_threads(
+                    owner, repo, pr_number, token, changed_line_map,
+                )
+                if resolved:
+                    console.print(f"[dim]Auto-resolved {resolved} outdated thread(s)[/dim]")
 
             # IMPORTANT: Review the FULL PR diff, not just changed files.
             # This ensures we see all commits in the PR, not just the latest one.
             # The full diff is against the base branch (e.g., main), so it includes
-            # all changes from all commits, which is what we want.
+            # all changes from all commits, which is what we want. This holds for
+            # every re-review path above, including the no-new-commits ones.
             review_diff_text = pr_data["diff"]
 
         except typer.Exit:
@@ -294,16 +371,63 @@ def review(
             except Exception as e:
                 console.print(f"[dim yellow]Could not create observation issues: {e}[/dim yellow]")
 
+        review_posted = False
+        post_outcome: dict = {}
         try:
             review_url = post_review(
                 owner, repo, pr_number, result, token,
                 diff=pr_data["diff"],
                 existing_comments=existing_comments or None,
                 observation_issues=observation_issues,
+                outcome=post_outcome,
             )
             console.print(f"[green]Review posted:[/green] {review_url}")
+            review_posted = True
         except Exception as e:
             console.print(f"[red]Error posting review:[/red] {e}")
+
+        # --- Withdraw Vigil's own stale blocks (issue #48) ---
+        # Only ever on the way UP: an APPROVE that GitHub actually accepted AS
+        # an approval. Three guards, all of which must hold, and all phrased
+        # positively so that missing or unexpected data fails closed:
+        #   1. the replacement review posted without raising,
+        #   2. this run's verdict is APPROVE,
+        #   3. GitHub accepted it as event=APPROVE — NOT a degraded COMMENT or
+        #      an issue-comment fallback. A COMMENT review does not clear a
+        #      block, so dismissing the old one there would leave the PR
+        #      completely unguarded. That is the worst failure mode available
+        #      in this change, hence the explicit equality check.
+        # A REQUEST_CHANGES verdict deliberately changes nothing: Vigil
+        # standing its ground is correct, and the escalation path exists for it.
+        if review_posted and result.decision == "APPROVE":
+            if post_outcome.get("submitted_event") == "APPROVE":
+                head_sha = pr_data["head_sha"]
+                # Belt and braces: dismiss_stale_vigil_blocks is written not to
+                # raise, but this cleanup must never be able to fail a review
+                # that has already posted. Vigil gates merges fleet-wide.
+                try:
+                    dismissed_ids = dismiss_stale_vigil_blocks(
+                        owner, repo, pr_number, token,
+                        message=(
+                            f"Superseded: Vigil re-reviewed {head_sha} and approved. "
+                            "This blocking review is withdrawn by its author."
+                        ),
+                    )
+                    if dismissed_ids:
+                        console.print(
+                            f"[dim]Dismissed {len(dismissed_ids)} stale Vigil block(s) "
+                            f"superseded by the approval at {head_sha[:7]}[/dim]"
+                        )
+                except Exception as e:
+                    console.print(
+                        f"[dim yellow]Could not dismiss stale Vigil block(s): {e}[/dim yellow]"
+                    )
+            else:
+                console.print(
+                    "[dim yellow]Approval did not post as an APPROVE event "
+                    f"({post_outcome.get('submitted_event', 'unknown')}) — "
+                    "leaving prior Vigil blocks in place[/dim yellow]"
+                )
 
         # Swap rocket for final reaction
         if rocket_id:

--- a/src/vigil/comment_manager.py
+++ b/src/vigil/comment_manager.py
@@ -4,6 +4,7 @@ import difflib
 import logging
 import re
 from collections import defaultdict
+from dataclasses import dataclass, field
 
 import httpx
 
@@ -184,12 +185,182 @@ def build_conversation_context(
 
 
 def get_last_reviewed_sha(owner: str, repo: str, pr_number: int, token: str) -> str | None:
-    """Find the most recent Vigil review and return its commit SHA."""
+    """Find the most recent Vigil review and return its commit SHA.
+
+    NOTE: this deliberately ignores review ``state`` — a DISMISSED review is
+    returned exactly like a live one. That is why it cannot be the only input
+    to the re-review decision; see ``get_vigil_review_state`` (issue #49).
+    """
     reviews = fetch_vigil_reviews(owner, repo, pr_number, token)
     if not reviews:
         return None
     latest = sorted(reviews, key=lambda r: r.get("submitted_at", ""), reverse=True)[0]
     return latest.get("commit_id")
+
+
+# --- Review-state inspection (issue #49) ---------------------------------
+#
+# GitHub review states we care about:
+#   APPROVED           - a standing approval
+#   CHANGES_REQUESTED  - a standing block
+#   COMMENTED          - a non-verdict review (what Vigil degrades to when it
+#                        lacks the write access to APPROVE/REQUEST_CHANGES)
+#   DISMISSED          - a verdict that has been withdrawn, by a human or by
+#                        the branch rule `dismiss_stale_reviews_on_push`.
+#                        Still returned by the reviews API.
+VIGIL_BLOCK_STATE = "CHANGES_REQUESTED"
+
+# States that mean "Vigil has already said its piece about this exact commit
+# and does not need to say it again". A DISMISSED review is excluded because
+# it has been withdrawn — that is the praxislms#263 shape, where the gate
+# could not be reopened even though nothing live remained at head.
+# CHANGES_REQUESTED is excluded because a standing block is precisely the
+# thing Vigil must be able to reconsider — that is the bioqms-core#1472 shape.
+# COMMENTED IS included on purpose: on a repo with no VIGIL_REVIEW_TOKEN every
+# Vigil review degrades to COMMENT, and treating those as unsettled would
+# re-review on every PR event forever.
+_SETTLED_VERDICT_STATES = frozenset({"APPROVED", "COMMENTED"})
+
+
+def _review_state(review: dict) -> str:
+    """Normalized upper-case review state ('' when absent)."""
+    return (review.get("state") or "").strip().upper()
+
+
+def select_outstanding_vigil_blocks(reviews: list[dict]) -> list[dict]:
+    """Vigil reviews still standing as CHANGES_REQUESTED.
+
+    Pure. A review that was later dismissed comes back from the API with
+    state DISMISSED, so filtering on CHANGES_REQUESTED already excludes it.
+    """
+    return [r for r in reviews if _review_state(r) == VIGIL_BLOCK_STATE]
+
+
+def has_settled_vigil_verdict_at(reviews: list[dict], head_sha: str | None) -> bool:
+    """True when Vigil has a live, settled verdict on this exact commit.
+
+    "Settled" means APPROVED or COMMENTED (see ``_SETTLED_VERDICT_STATES``).
+    A DISMISSED review at head does not count, which is what lets a
+    dismissed-verdict head reopen the review gate.
+
+    When ``head_sha`` is unknown this returns True — the conservative answer,
+    because the caller uses it to decide whether to spend a review, and we
+    would rather skip than re-review the world on missing data.
+    """
+    if not head_sha:
+        return True
+    return any(
+        r.get("commit_id") == head_sha and _review_state(r) in _SETTLED_VERDICT_STATES
+        for r in reviews
+    )
+
+
+@dataclass(frozen=True)
+class VigilReviewState:
+    """Everything the re-review decision needs, from a single reviews fetch."""
+
+    last_reviewed_sha: str | None = None
+    outstanding_blocks: list[dict] = field(default_factory=list)
+    settled_verdict_at_head: bool = True
+
+
+def get_vigil_review_state(
+    owner: str, repo: str, pr_number: int, token: str, head_sha: str | None = None,
+) -> VigilReviewState:
+    """Fetch Vigil's reviews once and summarize them for the review gate.
+
+    Sibling of ``get_last_reviewed_sha`` (whose signature is unchanged because
+    other callers depend on it). This one keeps the review ``state`` that
+    ``get_last_reviewed_sha`` collapses away.
+    """
+    reviews = fetch_vigil_reviews(owner, repo, pr_number, token)
+    if not reviews:
+        return VigilReviewState()
+    latest = sorted(reviews, key=lambda r: r.get("submitted_at", ""), reverse=True)[0]
+    return VigilReviewState(
+        last_reviewed_sha=latest.get("commit_id"),
+        outstanding_blocks=select_outstanding_vigil_blocks(reviews),
+        settled_verdict_at_head=has_settled_vigil_verdict_at(reviews, head_sha),
+    )
+
+
+def _dismiss_review(
+    owner: str, repo: str, pr_number: int, review_id: int, message: str, token: str,
+) -> bool:
+    """Dismiss one PR review via the REST dismissal endpoint. Never raises.
+
+    This is the injectable seam for issue #48: tests patch this function to
+    exercise both the accepted and the rejected branch without network access,
+    the same way ``_paginate`` and ``_graphql`` are patched elsewhere.
+
+    OPEN QUESTION (issue #48): GitHub hides self-dismissal in the UI, and
+    whether the REST endpoint permits an identity to dismiss its own review is
+    UNVERIFIED — it has deliberately not been exercised against a live PR. If
+    runtime logs show 403/422 here, the fallback the issue proposes is to
+    perform the dismissal under a second identity (GITHUB_TOKEN rather than
+    VIGIL_REVIEW_TOKEN). That credential switch is NOT implemented here
+    because it is equally untested; adding it blind would trade one unverified
+    path for another. Until then this degrades safely: log and carry on, so a
+    rejected dismissal costs a stale block, never an unguarded PR.
+    """
+    url = (
+        f"https://api.github.com/repos/{owner}/{repo}"
+        f"/pulls/{pr_number}/reviews/{review_id}/dismissals"
+    )
+    try:
+        resp = httpx.put(
+            url,
+            headers=_github_headers(token),
+            json={"message": message, "event": "DISMISS"},
+            timeout=30,
+        )
+    except Exception as e:  # network error, timeout, DNS, ...
+        log.warning("Dismissal request for review %s failed: %s", review_id, e)
+        return False
+
+    if resp.status_code >= 400:
+        # No retry: a 403/422 here is a permission verdict, not a blip, and a
+        # retry storm against a merge-gating control is worse than a stale block.
+        log.warning(
+            "GitHub rejected dismissal of review %s: %s %s",
+            review_id, resp.status_code, (resp.text or "")[:300],
+        )
+        return False
+
+    log.info("Dismissed stale Vigil block (review %s)", review_id)
+    return True
+
+
+def dismiss_stale_vigil_blocks(
+    owner: str, repo: str, pr_number: int, token: str, message: str,
+    reviews: list[dict] | None = None,
+) -> list[int]:
+    """Withdraw every Vigil review still standing as CHANGES_REQUESTED.
+
+    Returns the ids actually dismissed. Never raises — the caller has just put
+    a replacement verdict on record and must not fail the review because the
+    cleanup did not take.
+
+    Callers MUST have posted a genuine replacement approval first; see the
+    guards at the call site in cli.py (issue #48).
+    """
+    try:
+        candidates = (
+            reviews if reviews is not None
+            else fetch_vigil_reviews(owner, repo, pr_number, token)
+        )
+    except Exception as e:
+        log.warning("Could not fetch Vigil reviews to dismiss stale blocks: %s", e)
+        return []
+
+    dismissed: list[int] = []
+    for review in select_outstanding_vigil_blocks(candidates):
+        review_id = review.get("id")
+        if review_id is None:
+            continue
+        if _dismiss_review(owner, repo, pr_number, review_id, message, token):
+            dismissed.append(review_id)
+    return dismissed
 
 
 def _graphql(query: str, variables: dict, token: str) -> dict:

--- a/src/vigil/github_review.py
+++ b/src/vigil/github_review.py
@@ -285,6 +285,7 @@ def post_review(
     diff: str = "",
     existing_comments: list[dict] | None = None,
     observation_issues: list[tuple[Finding, str]] | None = None,
+    outcome: dict | None = None,
 ) -> str:
     """Post the review result as a GitHub PR review with inline comments.
 
@@ -308,6 +309,15 @@ def post_review(
             that were opened as GitHub issues. When provided, the review body
             renders observations as compact issue links instead of a
             collapsible details block.
+        outcome: Optional dict, populated in place with what was actually
+            submitted: ``requested_event`` (what result.decision maps to) and
+            ``submitted_event`` (what GitHub accepted — one of APPROVE,
+            REQUEST_CHANGES, COMMENT, or ISSUE_COMMENT when every review
+            attempt failed). Callers that act on the verdict landing — e.g.
+            dismissing Vigil's own stale blocks (issue #48) — must check
+            ``submitted_event``, because a degraded COMMENT review does not
+            clear a block and dismissing on that path would leave the PR
+            unguarded.
 
     Returns the URL of the created review.
     """
@@ -389,6 +399,14 @@ def post_review(
     }
     event = event_map.get(result.decision, "COMMENT")
 
+    # Tracks what GitHub actually accepted, as the fallback ladder degrades.
+    submitted_event = event
+
+    def _record_outcome() -> None:
+        if outcome is not None:
+            outcome["requested_event"] = event
+            outcome["submitted_event"] = submitted_event
+
     url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/reviews"
     headers = github_headers(token)
 
@@ -427,6 +445,9 @@ def post_review(
         # APPROVE and REQUEST_CHANGES require write/collaborator access.
         # On third-party repos we can only submit COMMENT reviews.
         log.info("Event '%s' rejected (likely no write access) - retrying with COMMENT", event)
+        # From here on the review carries no verdict: a COMMENT review neither
+        # approves nor blocks, so it cannot clear a standing CHANGES_REQUESTED.
+        submitted_event = "COMMENT"
         payload_comment: dict = {
             "body": body,
             "event": "COMMENT",
@@ -455,11 +476,14 @@ def post_review(
     if resp.status_code == 422:
         # --- Final fallback: post as a regular issue comment ---
         log.warning("All PR Review API attempts failed — falling back to issue comment")
+        submitted_event = "ISSUE_COMMENT"
         comment_url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/comments"
         resp = httpx.post(comment_url, headers=headers, json={"body": body}, timeout=30)
         resp.raise_for_status()
+        _record_outcome()
         return resp.json().get("html_url", pr_url_fallback)
 
     resp.raise_for_status()
     review_data = resp.json()
+    _record_outcome()
     return review_data.get("html_url", pr_url_fallback)

--- a/src/vigil/webhook.py
+++ b/src/vigil/webhook.py
@@ -89,12 +89,22 @@ def _should_dismiss(event: str, payload: dict) -> bool:
     return _is_resolution_reply(body)
 
 
-def _run_review(pr_url: str, model: str, lead_model: Optional[str], profile: str):
+def _run_review(
+    pr_url: str, model: str, lead_model: Optional[str], profile: str,
+    force: bool = False, reason: str = "",
+):
     """Run a Vigil review in a background thread."""
     import subprocess
     cmd = ["vigil", "review", pr_url, "--model", model, "--profile", profile, "--post"]
     if lead_model:
         cmd.extend(["--lead-model", lead_model])
+    # The webhook is the second entry point that serves '/vigil review'. It
+    # must forward the explicit-request signal too, or the escape hatch stays
+    # a no-op on an unchanged head under this deployment (F2iLLC/vigil#49).
+    if force:
+        cmd.append("--force")
+    if reason:
+        cmd.extend(["--reason", reason])
     log.info("Starting review: %s", " ".join(cmd))
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
@@ -168,9 +178,13 @@ def create_app(
 
         # Check if we should review
         if _should_review(event, payload):
+            # An issue_comment reaching here matched '/vigil review' in
+            # _should_review, so it is an explicit on-demand request.
+            explicit = event == "issue_comment"
             thread = threading.Thread(
                 target=_run_review,
-                args=(pr_url, model, lead_model, profile),
+                args=(pr_url, model, lead_model, profile, explicit,
+                      "on-demand /vigil review comment" if explicit else ""),
                 daemon=True,
             )
             thread.start()

--- a/tests/test_documentation_contract.py
+++ b/tests/test_documentation_contract.py
@@ -40,6 +40,8 @@ def test_readme_documents_every_public_action_input():
         "model",
         "lead-model",
         "profile",
+        "force",
+        "reason",
         "github-token",
         "gemini-api-key",
         "openai-api-key",

--- a/tests/test_rereview_and_dismissal.py
+++ b/tests/test_rereview_and_dismissal.py
@@ -1,0 +1,940 @@
+"""Tests for the re-review gate (#49) and Vigil self-dismissal (#48).
+
+These two issues are one defect with two halves. #49 is the trigger: the
+review short-circuits on an unchanged head, so a PR can reach a state it
+cannot leave. #48 is the action it enables: Vigil can issue REQUEST_CHANGES
+but has no way to withdraw one.
+
+Two real incidents shape the tests, and they differ in the way that matters:
+
+  * F2iLLC/bioqms-core#1472 - the block at head was left OUTSTANDING.
+  * F2iLLC/praxislms#263    - the block at head was DISMISSED, and the gate
+                              still could not be reopened because
+                              get_last_reviewed_sha returns a dismissed
+                              review's commit_id all the same.
+
+A trigger keyed only on "an outstanding CHANGES_REQUESTED exists" misses the
+second; one keyed only on "no live review at head" misses the first. Both
+shapes are asserted here.
+
+Mocking policy: these tests mock the GitHub API boundary (_paginate for reads,
+_dismiss_review / httpx for writes) and let the real selection, gating and
+dismissal logic run. The one place a collaborator is faked - post_review's
+`outcome` contract at the CLI level - is verified separately and for real
+against the actual HTTP fallback ladder in TestPostReviewOutcome.
+"""
+
+import re
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import typer
+from unittest.mock import MagicMock, patch
+
+from vigil import cli, comment_manager
+from vigil.comment_manager import (
+    dismiss_stale_vigil_blocks,
+    get_vigil_review_state,
+    has_settled_vigil_verdict_at,
+    select_outstanding_vigil_blocks,
+    _dismiss_review,
+)
+from vigil.github_review import post_review
+from vigil.models import ReviewResult
+
+
+SHA_A = "5e2c671" + "a" * 33
+SHA_B = "e0db6c1" + "b" * 33
+SHA_C = "c8b06b5" + "c" * 33
+
+PR_URL = "https://github.com/F2iLLC/demo/pull/1"
+
+# A two-file base-to-head diff. Re-review must always see BOTH files: the
+# full PR diff against the base, never just what moved since the last review.
+FULL_DIFF = """diff --git a/file_a.py b/file_a.py
+--- a/file_a.py
++++ b/file_a.py
+@@ -1,2 +1,3 @@
+ import os
++import sys
+
+diff --git a/file_b.py b/file_b.py
+--- a/file_b.py
++++ b/file_b.py
+@@ -1,2 +1,3 @@
+ import json
++import time
+
+"""
+
+
+def vigil_review(review_id: int, state: str, commit_id: str, submitted_at: str) -> dict:
+    """A Vigil-authored review record as the GitHub reviews API returns it."""
+    return {
+        "id": review_id,
+        "state": state,
+        "commit_id": commit_id,
+        "submitted_at": submitted_at,
+        "user": {"login": "vigil-reviewer"},
+        "body": "Reviewed by [Vigil] - AI-powered PR review\n\nSummary here.",
+    }
+
+
+def foreign_review(review_id: int, state: str, commit_id: str) -> dict:
+    """A review by somebody other than Vigil (must never be selected)."""
+    return {
+        "id": review_id,
+        "state": state,
+        "commit_id": commit_id,
+        "submitted_at": "2026-08-01T00:00:00Z",
+        "user": {"login": "F2iProject"},
+        "body": "Looks good to me.",
+    }
+
+
+def wire_review(
+    monkeypatch,
+    *,
+    reviews: list[dict],
+    changed_files: list[str],
+    decision: str = "APPROVE",
+    head_sha: str = SHA_C,
+    submitted_event: str | None = None,
+    omit_outcome: bool = False,
+    resolved_threads: int = 0,
+    dismiss_ok: bool = True,
+):
+    """Wire cli.review against fake GitHub I/O, returning a call recorder.
+
+    `reviews` is the live list the fake API serves; the fake dismissal endpoint
+    mutates it in place the way GitHub would, so multi-run sequences stay
+    faithful.
+    """
+    rec = SimpleNamespace(review_diffs=[], dismissals=[], posted=[], reviews=reviews)
+
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(cli, "parse_pr_url", lambda pr_url: ("F2iLLC", "demo", 1))
+    monkeypatch.setattr(
+        cli, "get_pr_data",
+        lambda *a: {
+            "title": "A pull request",
+            "author": "someone",
+            "additions": 2,
+            "deletions": 0,
+            "changed_files": 2,
+            "head_sha": head_sha,
+            "diff": FULL_DIFF,
+            "url": PR_URL,
+        },
+    )
+
+    # --- GitHub read boundary. The real fetch_vigil_reviews signature filter,
+    # the real state selection and the real gate all run on top of this. ---
+    def fake_paginate(url, headers, params=None):
+        if url.endswith("/reviews"):
+            return list(reviews)
+        return []
+
+    monkeypatch.setattr(comment_manager, "_paginate", fake_paginate)
+
+    monkeypatch.setattr(cli, "resolve_dismissed_threads", lambda *a: resolved_threads)
+    monkeypatch.setattr(cli, "resolve_addressed_threads", lambda *a, **k: 0)
+    monkeypatch.setattr(cli, "get_changed_files_between_commits", lambda *a: list(changed_files))
+    monkeypatch.setattr(cli, "fetch_all_vigil_comments", lambda *a: [])
+    monkeypatch.setattr(cli, "write_audit_entry", lambda *a, **k: "/tmp/audit.db")
+    monkeypatch.setattr(cli, "react", lambda *a: None)
+    monkeypatch.setattr(cli, "remove_reaction", lambda *a: None)
+
+    result = ReviewResult(
+        decision=decision,
+        summary="summary",
+        commit_sha=head_sha,
+        specialist_verdicts=[],
+        lead_findings=[],
+        observations=[],
+    )
+
+    def fake_review_diff(diff, pr_context, **kwargs):
+        rec.review_diffs.append(diff)
+        return result
+
+    monkeypatch.setattr(cli, "review_diff", fake_review_diff)
+
+    default_event = {
+        "APPROVE": "APPROVE",
+        "REQUEST_CHANGES": "REQUEST_CHANGES",
+        "BLOCK": "REQUEST_CHANGES",
+    }.get(decision, "COMMENT")
+
+    def fake_post_review(owner, repo, pr_number, res, token, **kwargs):
+        outcome = kwargs.get("outcome")
+        if outcome is not None and not omit_outcome:
+            outcome["requested_event"] = default_event
+            outcome["submitted_event"] = submitted_event or default_event
+        rec.posted.append(res.decision)
+        return PR_URL + "#pullrequestreview-99"
+
+    monkeypatch.setattr(cli, "post_review", fake_post_review)
+
+    # --- GitHub write boundary for dismissals. Mutates the served review list
+    # exactly as GitHub does: the review comes back with state DISMISSED. ---
+    def fake_dismiss(owner, repo, pr_number, review_id, message, token):
+        rec.dismissals.append((review_id, message))
+        if not dismiss_ok:
+            return False
+        for r in reviews:
+            if r.get("id") == review_id:
+                r["state"] = "DISMISSED"
+        return True
+
+    monkeypatch.setattr(comment_manager, "_dismiss_review", fake_dismiss)
+    return rec
+
+
+def run_review(*, force: bool = False, reason: str = ""):
+    """Invoke the CLI command with every option supplied explicitly.
+
+    Calling a typer command directly leaves un-passed parameters as OptionInfo
+    sentinels rather than values, so all of them are passed here.
+    """
+    return cli.review(
+        PR_URL,
+        model="gemini/gemini-3.1-flash-lite",
+        lead_model=None,
+        profile="default",
+        output_json=False,
+        post=True,
+        force=force,
+        reason=reason,
+    )
+
+
+# ---------- pure selection helpers ----------
+
+class TestSelectOutstandingVigilBlocks:
+
+    def test_selects_live_changes_requested(self):
+        reviews = [vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z")]
+        assert [r["id"] for r in select_outstanding_vigil_blocks(reviews)] == [1]
+
+    def test_excludes_dismissed_block(self):
+        """The praxislms#263 shape: dismissed, so nothing is standing."""
+        reviews = [vigil_review(1, "DISMISSED", SHA_C, "2026-08-01T00:00:00Z")]
+        assert select_outstanding_vigil_blocks(reviews) == []
+
+    def test_excludes_approved_and_commented(self):
+        reviews = [
+            vigil_review(1, "APPROVED", SHA_A, "2026-08-01T00:00:00Z"),
+            vigil_review(2, "COMMENTED", SHA_A, "2026-08-01T00:01:00Z"),
+        ]
+        assert select_outstanding_vigil_blocks(reviews) == []
+
+    def test_state_matching_is_case_insensitive_and_null_safe(self):
+        reviews = [
+            {"id": 1, "state": "changes_requested", "commit_id": SHA_A},
+            {"id": 2, "state": None, "commit_id": SHA_A},
+            {"id": 3, "commit_id": SHA_A},
+        ]
+        assert [r["id"] for r in select_outstanding_vigil_blocks(reviews)] == [1]
+
+
+class TestHasSettledVigilVerdictAt:
+
+    def test_approved_at_head_is_settled(self):
+        reviews = [vigil_review(1, "APPROVED", SHA_C, "2026-08-01T00:00:00Z")]
+        assert has_settled_vigil_verdict_at(reviews, SHA_C) is True
+
+    def test_commented_at_head_is_settled(self):
+        """A repo with no VIGIL_REVIEW_TOKEN only ever gets COMMENT reviews.
+
+        Treating those as unsettled would re-review on every PR event forever,
+        which is the cost regression this gate must not cause.
+        """
+        reviews = [vigil_review(1, "COMMENTED", SHA_C, "2026-08-01T00:00:00Z")]
+        assert has_settled_vigil_verdict_at(reviews, SHA_C) is True
+
+    def test_dismissed_at_head_is_not_settled(self):
+        reviews = [vigil_review(1, "DISMISSED", SHA_C, "2026-08-01T00:00:00Z")]
+        assert has_settled_vigil_verdict_at(reviews, SHA_C) is False
+
+    def test_changes_requested_at_head_is_not_settled(self):
+        reviews = [vigil_review(1, "CHANGES_REQUESTED", SHA_C, "2026-08-01T00:00:00Z")]
+        assert has_settled_vigil_verdict_at(reviews, SHA_C) is False
+
+    def test_approval_on_a_different_commit_does_not_settle_head(self):
+        reviews = [vigil_review(1, "APPROVED", SHA_B, "2026-08-01T00:00:00Z")]
+        assert has_settled_vigil_verdict_at(reviews, SHA_C) is False
+
+    def test_missing_head_sha_is_treated_as_settled(self):
+        """Conservative on unknown data: skip rather than spend a review."""
+        assert has_settled_vigil_verdict_at([], None) is True
+        assert has_settled_vigil_verdict_at([], "") is True
+
+
+class TestGetVigilReviewState:
+
+    @patch("vigil.comment_manager._paginate")
+    def test_ignores_non_vigil_reviews(self, mock_paginate):
+        mock_paginate.return_value = [
+            foreign_review(9, "CHANGES_REQUESTED", SHA_C),
+            vigil_review(1, "APPROVED", SHA_C, "2026-08-01T00:00:00Z"),
+        ]
+        state = get_vigil_review_state("o", "r", 1, "t", SHA_C)
+        assert state.outstanding_blocks == []
+        assert state.settled_verdict_at_head is True
+        assert state.last_reviewed_sha == SHA_C
+
+    @patch("vigil.comment_manager._paginate")
+    def test_last_reviewed_sha_still_comes_from_a_dismissed_review(self, mock_paginate):
+        """The exact root cause: state is collapsed away by SHA alone.
+
+        get_vigil_review_state reports the same SHA, but carries the state
+        that lets the caller tell the difference.
+        """
+        mock_paginate.return_value = [
+            vigil_review(1, "DISMISSED", SHA_C, "2026-08-01T00:00:00Z"),
+        ]
+        state = get_vigil_review_state("o", "r", 1, "t", SHA_C)
+        assert state.last_reviewed_sha == SHA_C
+        assert state.settled_verdict_at_head is False
+
+    @patch("vigil.comment_manager._paginate")
+    def test_no_reviews_is_empty_state(self, mock_paginate):
+        mock_paginate.return_value = []
+        state = get_vigil_review_state("o", "r", 1, "t", SHA_C)
+        assert state.last_reviewed_sha is None
+        assert state.outstanding_blocks == []
+        assert state.settled_verdict_at_head is True
+
+
+# ---------- the pure gate ----------
+
+class TestRereviewReasons:
+
+    def _reasons(self, **kw):
+        base = dict(
+            forced=False,
+            reason="",
+            outstanding_blocks=[],
+            settled_verdict_at_head=True,
+            resolved_threads=0,
+        )
+        base.update(kw)
+        return cli._rereview_reasons(**base)
+
+    def test_ordinary_case_has_no_reasons(self):
+        assert self._reasons() == []
+
+    def test_forced(self):
+        assert self._reasons(forced=True) != []
+
+    def test_forced_records_the_reason_text(self):
+        assert "on-demand" in self._reasons(forced=True, reason="on-demand")[0]
+
+    def test_outstanding_block(self):
+        assert self._reasons(outstanding_blocks=[{"id": 1}]) != []
+
+    def test_no_settled_verdict_at_head(self):
+        assert self._reasons(settled_verdict_at_head=False) != []
+
+    def test_resolved_threads(self):
+        assert self._reasons(resolved_threads=2) != []
+
+
+# ---------- issue #49: the re-review gate, end to end through cli.review ----------
+
+class TestRereviewGate:
+
+    def test_ordinary_case_still_short_circuits(self, monkeypatch):
+        """Cost guard. No new commits, no block, nobody asked -> skip."""
+        rec = wire_review(
+            monkeypatch,
+            reviews=[vigil_review(1, "APPROVED", SHA_C, "2026-08-01T00:00:00Z")],
+            changed_files=[],
+        )
+        with pytest.raises(typer.Exit) as exc:
+            run_review()
+        assert exc.value.exit_code == 0
+        assert rec.review_diffs == [], "no review should have been run"
+        assert rec.posted == []
+
+    def test_comment_only_repo_still_short_circuits(self, monkeypatch):
+        """Cost guard for repos with no VIGIL_REVIEW_TOKEN (COMMENT reviews)."""
+        rec = wire_review(
+            monkeypatch,
+            reviews=[vigil_review(1, "COMMENTED", SHA_C, "2026-08-01T00:00:00Z")],
+            changed_files=[],
+        )
+        with pytest.raises(typer.Exit) as exc:
+            run_review()
+        assert exc.value.exit_code == 0
+        assert rec.review_diffs == []
+
+    def test_explicit_request_reviews_an_unchanged_head(self, monkeypatch):
+        """/vigil review produces a fresh verdict even at a settled head."""
+        rec = wire_review(
+            monkeypatch,
+            reviews=[vigil_review(1, "APPROVED", SHA_C, "2026-08-01T00:00:00Z")],
+            changed_files=[],
+        )
+        run_review(force=True, reason="on-demand /vigil review comment")
+        assert rec.review_diffs == [FULL_DIFF]
+        assert rec.posted == ["APPROVE"]
+
+    def test_outstanding_block_reviews_without_new_commits(self, monkeypatch):
+        """The bioqms-core#1472 shape: live CHANGES_REQUESTED at head."""
+        reviews = [vigil_review(1, "CHANGES_REQUESTED", SHA_C, "2026-08-01T00:00:00Z")]
+        rec = wire_review(monkeypatch, reviews=reviews, changed_files=[])
+        run_review()
+        assert rec.review_diffs == [FULL_DIFF]
+
+    def test_dismissed_verdict_at_head_reviews_without_new_commits(self, monkeypatch):
+        """The praxislms#263 shape, which a naive implementation gets wrong.
+
+        Nothing is outstanding here - the block was dismissed - so a trigger
+        keyed on "an outstanding CHANGES_REQUESTED exists" would not fire.
+        The assertion below proves that premise before asserting the fix.
+        """
+        reviews = [vigil_review(1, "DISMISSED", SHA_C, "2026-08-01T00:00:00Z")]
+        assert select_outstanding_vigil_blocks(reviews) == [], (
+            "premise: the naive outstanding-block trigger would NOT fire here"
+        )
+        rec = wire_review(monkeypatch, reviews=reviews, changed_files=[])
+        run_review()
+        assert rec.review_diffs == [FULL_DIFF]
+
+    def test_resolved_threads_since_last_review_trigger_rereview(self, monkeypatch):
+        rec = wire_review(
+            monkeypatch,
+            reviews=[vigil_review(1, "APPROVED", SHA_C, "2026-08-01T00:00:00Z")],
+            changed_files=[],
+            resolved_threads=3,
+        )
+        run_review()
+        assert rec.review_diffs == [FULL_DIFF]
+
+    @pytest.mark.parametrize(
+        "reviews,force,resolved",
+        [
+            ([vigil_review(1, "APPROVED", SHA_C, "2026-08-01T00:00:00Z")], True, 0),
+            ([vigil_review(1, "CHANGES_REQUESTED", SHA_C, "2026-08-01T00:00:00Z")], False, 0),
+            ([vigil_review(1, "DISMISSED", SHA_C, "2026-08-01T00:00:00Z")], False, 0),
+            ([vigil_review(1, "APPROVED", SHA_C, "2026-08-01T00:00:00Z")], False, 2),
+        ],
+        ids=["forced", "outstanding-block", "dismissed-head", "threads-resolved"],
+    )
+    def test_every_rereview_path_uses_the_full_base_to_head_diff(
+        self, monkeypatch, reviews, force, resolved,
+    ):
+        rec = wire_review(
+            monkeypatch, reviews=reviews, changed_files=[], resolved_threads=resolved,
+        )
+        run_review(force=force)
+        assert len(rec.review_diffs) == 1
+        reviewed = rec.review_diffs[0]
+        assert reviewed == FULL_DIFF
+        # Both files from the base-to-head diff, not just what moved last.
+        assert "file_a.py" in reviewed
+        assert "file_b.py" in reviewed
+
+    def test_no_empty_commit_is_required_to_clear_a_stale_block(self, monkeypatch):
+        """Regression for the forbidden workaround.
+
+        The head SHA is identical across the blocking review and the re-review,
+        and the changed-file set is empty - i.e. nothing was pushed - yet a
+        fresh verdict lands and the block is withdrawn.
+        """
+        reviews = [vigil_review(1, "CHANGES_REQUESTED", SHA_C, "2026-08-01T00:00:00Z")]
+        rec = wire_review(
+            monkeypatch, reviews=reviews, changed_files=[], head_sha=SHA_C,
+            decision="APPROVE",
+        )
+        run_review()
+        assert rec.review_diffs == [FULL_DIFF]
+        assert rec.posted == ["APPROVE"]
+        assert [d[0] for d in rec.dismissals] == [1]
+        assert select_outstanding_vigil_blocks(reviews) == []
+
+
+# ---------- issue #48: withdrawing Vigil's own block ----------
+
+class TestApproveDismissesStaleBlocks:
+
+    def test_approve_dismisses_prior_vigil_blocks(self, monkeypatch):
+        reviews = [
+            vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z"),
+            vigil_review(2, "CHANGES_REQUESTED", SHA_B, "2026-08-01T01:00:00Z"),
+        ]
+        rec = wire_review(
+            monkeypatch, reviews=reviews, changed_files=["file_a.py"], decision="APPROVE",
+        )
+        run_review()
+        assert [d[0] for d in rec.dismissals] == [1, 2]
+
+    def test_dismissal_message_names_the_head_sha(self, monkeypatch):
+        reviews = [vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z")]
+        rec = wire_review(
+            monkeypatch, reviews=reviews, changed_files=["file_a.py"],
+            decision="APPROVE", head_sha=SHA_C,
+        )
+        run_review()
+        assert SHA_C in rec.dismissals[0][1]
+
+    def test_request_changes_leaves_prior_verdicts_untouched(self, monkeypatch):
+        reviews = [vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z")]
+        rec = wire_review(
+            monkeypatch, reviews=reviews, changed_files=["file_a.py"],
+            decision="REQUEST_CHANGES",
+        )
+        run_review()
+        assert rec.dismissals == []
+        assert reviews[0]["state"] == "CHANGES_REQUESTED"
+
+    def test_block_verdict_leaves_prior_verdicts_untouched(self, monkeypatch):
+        reviews = [vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z")]
+        rec = wire_review(
+            monkeypatch, reviews=reviews, changed_files=["file_a.py"], decision="BLOCK",
+        )
+        run_review()
+        assert rec.dismissals == []
+
+    def test_no_dismissal_when_review_degraded_to_comment(self, monkeypatch):
+        """The most dangerous failure mode: a COMMENT review clears no block,
+        so dismissing the old one would leave the PR completely unguarded."""
+        reviews = [vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z")]
+        rec = wire_review(
+            monkeypatch, reviews=reviews, changed_files=["file_a.py"],
+            decision="APPROVE", submitted_event="COMMENT",
+        )
+        run_review()
+        assert rec.dismissals == []
+        assert reviews[0]["state"] == "CHANGES_REQUESTED"
+
+    def test_no_dismissal_when_review_fell_back_to_an_issue_comment(self, monkeypatch):
+        reviews = [vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z")]
+        rec = wire_review(
+            monkeypatch, reviews=reviews, changed_files=["file_a.py"],
+            decision="APPROVE", submitted_event="ISSUE_COMMENT",
+        )
+        run_review()
+        assert rec.dismissals == []
+
+    def test_no_dismissal_when_the_outcome_is_unknown(self, monkeypatch):
+        """Fails closed: an unpopulated outcome must not authorize a dismissal."""
+        reviews = [vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z")]
+        rec = wire_review(
+            monkeypatch, reviews=reviews, changed_files=["file_a.py"],
+            decision="APPROVE", omit_outcome=True,
+        )
+        run_review()
+        assert rec.dismissals == []
+
+    def test_no_dismissal_when_posting_the_replacement_raised(self, monkeypatch):
+        """Never withdraw a block without a replacement verdict on record."""
+        reviews = [vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z")]
+        rec = wire_review(
+            monkeypatch, reviews=reviews, changed_files=["file_a.py"], decision="APPROVE",
+        )
+
+        def boom(*a, **k):
+            raise httpx.HTTPError("review submission failed")
+
+        monkeypatch.setattr(cli, "post_review", boom)
+        run_review()
+        assert rec.dismissals == []
+        assert reviews[0]["state"] == "CHANGES_REQUESTED"
+
+    def test_verdict_guard_holds_independently_of_the_event_guard(self, monkeypatch):
+        """Defense in depth, guard 2 of 3.
+
+        In production the verdict and the submitted event agree, so the event
+        guard alone would mask a missing verdict guard. This forces the
+        pathological pairing to prove the verdict check is load-bearing on its
+        own: a REQUEST_CHANGES verdict must never dismiss a block, whatever
+        GitHub reports about the event.
+        """
+        reviews = [vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z")]
+        rec = wire_review(
+            monkeypatch, reviews=reviews, changed_files=["file_a.py"],
+            decision="REQUEST_CHANGES", submitted_event="APPROVE",
+        )
+        run_review()
+        assert rec.dismissals == []
+        assert reviews[0]["state"] == "CHANGES_REQUESTED"
+
+    def test_posted_guard_holds_independently_of_the_event_guard(self, monkeypatch):
+        """Defense in depth, guard 1 of 3.
+
+        A replacement verdict that did not land must not authorize withdrawing
+        the old block, even if the outcome dict was already populated before
+        the failure.
+        """
+        reviews = [vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z")]
+        rec = wire_review(
+            monkeypatch, reviews=reviews, changed_files=["file_a.py"], decision="APPROVE",
+        )
+
+        def populate_then_fail(owner, repo, pr_number, res, token, **kwargs):
+            outcome = kwargs.get("outcome")
+            if outcome is not None:
+                outcome["requested_event"] = "APPROVE"
+                outcome["submitted_event"] = "APPROVE"
+            raise httpx.HTTPError("connection reset after submit")
+
+        monkeypatch.setattr(cli, "post_review", populate_then_fail)
+        run_review()
+        assert rec.dismissals == []
+        assert reviews[0]["state"] == "CHANGES_REQUESTED"
+
+    def test_rejected_dismissal_does_not_fail_the_review(self, monkeypatch):
+        """Degrade safely: a 403 costs a stale block, never the review."""
+        reviews = [vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z")]
+        rec = wire_review(
+            monkeypatch, reviews=reviews, changed_files=["file_a.py"],
+            decision="APPROVE", dismiss_ok=False,
+        )
+        run_review()  # must not raise
+        assert [d[0] for d in rec.dismissals] == [1]
+        assert reviews[0]["state"] == "CHANGES_REQUESTED"
+
+    def test_unexpected_dismissal_error_does_not_fail_the_review(self, monkeypatch):
+        """Even an exception escaping the helper must not fail a posted review."""
+        reviews = [vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z")]
+        rec = wire_review(
+            monkeypatch, reviews=reviews, changed_files=["file_a.py"], decision="APPROVE",
+        )
+
+        def boom(*a, **k):
+            raise httpx.HTTPStatusError("403", request=MagicMock(), response=MagicMock())
+
+        monkeypatch.setattr(cli, "dismiss_stale_vigil_blocks", boom)
+        run_review()  # must not raise
+        assert rec.posted == ["APPROVE"]
+
+
+class TestStaleDismissalResurrection:
+    """Issue #48's headline sequence: block at A -> approve at B -> push C.
+
+    Before the fix, the branch rule `dismiss_stale_reviews_on_push` dropped the
+    APPROVE from B on any push and left the block from A untouched, so the
+    block became the latest live review again and re-blocked the PR on a
+    verdict Vigil had already retracted.
+    """
+
+    def test_block_cannot_resurrect_after_an_approval_is_stale_dismissed(self, monkeypatch):
+        reviews: list[dict] = []
+
+        # --- Round 1: head A. Vigil blocks. ---
+        wire_review(monkeypatch, reviews=reviews, changed_files=["file_a.py"],
+                    decision="REQUEST_CHANGES", head_sha=SHA_A)
+        run_review()
+        reviews.append(vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z"))
+        assert [r["id"] for r in select_outstanding_vigil_blocks(reviews)] == [1]
+
+        # --- Round 2: author pushes B. Vigil re-reviews and approves. ---
+        rec2 = wire_review(monkeypatch, reviews=reviews, changed_files=["file_a.py"],
+                           decision="APPROVE", head_sha=SHA_B)
+        run_review()
+        # The approval landed, and the block from A was withdrawn by its author.
+        assert [d[0] for d in rec2.dismissals] == [1]
+        assert reviews[0]["state"] == "DISMISSED"
+        reviews.append(vigil_review(2, "APPROVED", SHA_B, "2026-08-01T02:00:00Z"))
+
+        # --- Round 3: anything pushes C. GitHub stale-dismisses APPROVALS
+        #     only - exactly the behavior that used to resurrect the block. ---
+        for r in reviews:
+            if r["state"] == "APPROVED":
+                r["state"] = "DISMISSED"
+
+        assert select_outstanding_vigil_blocks(reviews) == [], (
+            "the retracted block must not come back as the latest live review"
+        )
+
+        # And the PR is not left stranded either: with no settled verdict at C,
+        # the gate reopens instead of skipping.
+        assert has_settled_vigil_verdict_at(reviews, SHA_C) is False
+        rec3 = wire_review(monkeypatch, reviews=reviews, changed_files=[],
+                           decision="APPROVE", head_sha=SHA_C)
+        run_review()
+        assert rec3.review_diffs == [FULL_DIFF]
+
+
+# ---------- the dismissal seam itself ----------
+
+def _resp(status_code=200, text=""):
+    """A mock response that raises from raise_for_status on 4xx/5xx.
+
+    Matching real httpx behavior matters here: a mock whose raise_for_status
+    silently succeeds would hide an implementation that calls it instead of
+    inspecting status_code, which is exactly the not-degrading-safely bug
+    these tests exist to catch.
+    """
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.text = text
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            str(status_code), request=MagicMock(), response=resp,
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+class TestDismissReviewSeam:
+
+    @patch("vigil.comment_manager.httpx.put")
+    def test_calls_the_dismissals_endpoint(self, mock_put):
+        mock_put.return_value = _resp(200)
+        assert _dismiss_review("o", "r", 7, 4242, "superseded", "tok") is True
+        url = mock_put.call_args[0][0]
+        assert url == (
+            "https://api.github.com/repos/o/r/pulls/7/reviews/4242/dismissals"
+        )
+        assert mock_put.call_args.kwargs["json"] == {
+            "message": "superseded", "event": "DISMISS",
+        }
+
+    @patch("vigil.comment_manager.httpx.put")
+    def test_403_returns_false_without_raising(self, mock_put):
+        """Self-dismissal permission is UNVERIFIED; a refusal must be survivable."""
+        mock_put.return_value = _resp(403, "Forbidden")
+        assert _dismiss_review("o", "r", 7, 1, "m", "tok") is False
+
+    @patch("vigil.comment_manager.httpx.put")
+    def test_422_returns_false_without_raising(self, mock_put):
+        mock_put.return_value = _resp(422, "Unprocessable")
+        assert _dismiss_review("o", "r", 7, 1, "m", "tok") is False
+
+    @patch("vigil.comment_manager.httpx.put")
+    def test_network_error_returns_false_without_raising(self, mock_put):
+        mock_put.side_effect = httpx.ConnectError("no route to host")
+        assert _dismiss_review("o", "r", 7, 1, "m", "tok") is False
+
+    @patch("vigil.comment_manager.httpx.put")
+    def test_does_not_retry(self, mock_put):
+        mock_put.return_value = _resp(403)
+        _dismiss_review("o", "r", 7, 1, "m", "tok")
+        assert mock_put.call_count == 1
+
+
+class TestDismissStaleVigilBlocks:
+
+    @patch("vigil.comment_manager._dismiss_review")
+    def test_selects_only_outstanding_blocks(self, mock_dismiss):
+        mock_dismiss.return_value = True
+        reviews = [
+            vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z"),
+            vigil_review(2, "APPROVED", SHA_B, "2026-08-01T01:00:00Z"),
+            vigil_review(3, "DISMISSED", SHA_A, "2026-08-01T02:00:00Z"),
+            vigil_review(4, "COMMENTED", SHA_B, "2026-08-01T03:00:00Z"),
+        ]
+        assert dismiss_stale_vigil_blocks("o", "r", 1, "t", "msg", reviews=reviews) == [1]
+
+    @patch("vigil.comment_manager._dismiss_review")
+    def test_continues_past_a_rejected_dismissal(self, mock_dismiss):
+        mock_dismiss.side_effect = [False, True]
+        reviews = [
+            vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z"),
+            vigil_review(2, "CHANGES_REQUESTED", SHA_B, "2026-08-01T01:00:00Z"),
+        ]
+        assert dismiss_stale_vigil_blocks("o", "r", 1, "t", "msg", reviews=reviews) == [2]
+        assert mock_dismiss.call_count == 2
+
+    @patch("vigil.comment_manager.fetch_vigil_reviews")
+    def test_fetch_failure_degrades_to_no_op(self, mock_fetch):
+        mock_fetch.side_effect = httpx.HTTPError("boom")
+        assert dismiss_stale_vigil_blocks("o", "r", 1, "t", "msg") == []
+
+    @patch("vigil.comment_manager._paginate")
+    @patch("vigil.comment_manager._dismiss_review")
+    def test_ignores_non_vigil_blocks(self, mock_dismiss, mock_paginate):
+        mock_dismiss.return_value = True
+        mock_paginate.return_value = [
+            foreign_review(9, "CHANGES_REQUESTED", SHA_C),
+            vigil_review(1, "CHANGES_REQUESTED", SHA_A, "2026-08-01T00:00:00Z"),
+        ]
+        assert dismiss_stale_vigil_blocks("o", "r", 1, "t", "msg") == [1]
+
+    @patch("vigil.comment_manager._dismiss_review")
+    def test_skips_records_without_an_id(self, mock_dismiss):
+        mock_dismiss.return_value = True
+        assert dismiss_stale_vigil_blocks(
+            "o", "r", 1, "t", "msg", reviews=[{"state": "CHANGES_REQUESTED"}],
+        ) == []
+        assert mock_dismiss.call_count == 0
+
+
+# ---------- post_review's outcome contract, against the real fallback ladder ----------
+
+class TestPostReviewOutcome:
+    """Verifies for real what the CLI-level tests take on contract.
+
+    Only the HTTP boundary is mocked; the actual 422 fallback ladder runs.
+    """
+
+    def _result(self, decision="APPROVE"):
+        return ReviewResult(
+            decision=decision, summary="s", commit_sha=SHA_C,
+            specialist_verdicts=[], lead_findings=[], observations=[],
+        )
+
+    @patch("vigil.github_review.httpx.post")
+    def test_accepted_approve_records_approve(self, mock_post):
+        ok = MagicMock(status_code=200, text="")
+        ok.json.return_value = {"html_url": "u"}
+        mock_post.return_value = ok
+
+        outcome: dict = {}
+        post_review("o", "r", 1, self._result(), "tok", outcome=outcome)
+        assert outcome["requested_event"] == "APPROVE"
+        assert outcome["submitted_event"] == "APPROVE"
+
+    @patch("vigil.github_review.httpx.post")
+    def test_degradation_to_comment_is_recorded(self, mock_post):
+        """422 on APPROVE (no write access) -> retried as COMMENT."""
+        rejected = MagicMock(status_code=422, text="not permitted")
+        ok = MagicMock(status_code=200, text="")
+        ok.json.return_value = {"html_url": "u"}
+        mock_post.side_effect = [rejected, ok]
+
+        outcome: dict = {}
+        post_review("o", "r", 1, self._result(), "tok", outcome=outcome)
+        assert outcome["requested_event"] == "APPROVE"
+        assert outcome["submitted_event"] == "COMMENT"
+        # The second attempt really did go out as a COMMENT review.
+        assert mock_post.call_args_list[1].kwargs["json"]["event"] == "COMMENT"
+
+    @patch("vigil.github_review.httpx.post")
+    def test_issue_comment_fallback_is_recorded(self, mock_post):
+        rejected = MagicMock(status_code=422, text="nope")
+        ok = MagicMock(status_code=200, text="")
+        ok.json.return_value = {"html_url": "u"}
+        mock_post.side_effect = [rejected, rejected, ok]
+
+        outcome: dict = {}
+        post_review("o", "r", 1, self._result(), "tok", outcome=outcome)
+        assert outcome["submitted_event"] == "ISSUE_COMMENT"
+        assert "/issues/1/comments" in mock_post.call_args_list[2].args[0]
+
+    @patch("vigil.github_review.httpx.post")
+    def test_request_changes_is_recorded(self, mock_post):
+        ok = MagicMock(status_code=200, text="")
+        ok.json.return_value = {"html_url": "u"}
+        mock_post.return_value = ok
+
+        outcome: dict = {}
+        post_review("o", "r", 1, self._result("REQUEST_CHANGES"), "tok", outcome=outcome)
+        assert outcome["submitted_event"] == "REQUEST_CHANGES"
+
+    @patch("vigil.github_review.httpx.post")
+    def test_outcome_is_optional(self, mock_post):
+        ok = MagicMock(status_code=200, text="")
+        ok.json.return_value = {"html_url": "u"}
+        mock_post.return_value = ok
+        assert post_review("o", "r", 1, self._result(), "tok") == "u"
+
+
+# ---------- workflow plumbing for the explicit-request signal ----------
+
+class TestExplicitRequestPlumbing:
+    """The --force signal is useless unless it reaches the CLI (issue #49)."""
+
+    def _read(self, name):
+        from pathlib import Path
+        root = Path(__file__).resolve().parent.parent
+        return (root / name).read_text()
+
+    def test_action_declares_force_and_reason_inputs(self):
+        action = self._read("action.yml")
+        assert re.search(r"^  force:", action, re.MULTILINE)
+        assert re.search(r"^  reason:", action, re.MULTILINE)
+
+    def test_action_forwards_force_and_reason_to_the_cli(self):
+        action = self._read("action.yml")
+        assert "ARGS+=(--force)" in action
+        assert 'ARGS+=(--reason "$VIGIL_REASON")' in action
+        # Passed via env, not interpolated into the shell script body.
+        assert "VIGIL_FORCE: ${{ inputs.force }}" in action
+        assert "VIGIL_REASON: ${{ inputs.reason }}" in action
+
+    def test_reusable_workflow_forces_on_the_issue_comment_trigger(self):
+        wf = self._read(".github/workflows/reusable-vigil.yml")
+        assert "force=true" in wf
+        assert "force=false" in wf
+        assert "force: ${{ steps.pr.outputs.force }}" in wf
+        assert "reason: ${{ steps.pr.outputs.reason }}" in wf
+
+
+class TestWebhookForcesOnDemandReviews:
+    """The webhook is the second entry point that serves '/vigil review'."""
+
+    def _cmd(self, **kwargs):
+        from vigil import webhook
+        captured = {}
+
+        class FakeCompleted:
+            returncode = 0
+            stderr = ""
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            return FakeCompleted()
+
+        with patch("subprocess.run", fake_run):
+            webhook._run_review("https://x/pull/1", "m", None, "default", **kwargs)
+        return captured["cmd"]
+
+    def test_forwards_force_and_reason(self):
+        cmd = self._cmd(force=True, reason="on-demand /vigil review comment")
+        assert "--force" in cmd
+        assert cmd[cmd.index("--reason") + 1] == "on-demand /vigil review comment"
+
+    def test_omits_force_for_ordinary_events(self):
+        assert "--force" not in self._cmd()
+
+    def _dispatch(self, event: str, payload: dict):
+        """POST a webhook event and return the args _run_review was given."""
+        from fastapi.testclient import TestClient
+        from vigil import webhook
+
+        captured = {}
+
+        class FakeThread:
+            def __init__(self, target=None, args=(), daemon=None):
+                captured["target"] = target
+                captured["args"] = args
+
+            def start(self):
+                pass
+
+        with patch.object(webhook.threading, "Thread", FakeThread):
+            client = TestClient(webhook.create_app(webhook_secret=""))
+            client.post("/webhook", json=payload, headers={"X-GitHub-Event": event})
+        return captured.get("args")
+
+    def test_slash_command_comment_dispatches_a_forced_review(self):
+        args = self._dispatch("issue_comment", {
+            "action": "created",
+            "comment": {"body": "/vigil review"},
+            "issue": {
+                "number": 1,
+                "pull_request": {"html_url": "https://github.com/o/r/pull/1"},
+                "html_url": "https://github.com/o/r/issues/1",
+            },
+        })
+        assert args is not None, "no review was dispatched"
+        assert args[4] is True, "the on-demand request must be forced"
+
+    def test_pull_request_event_dispatches_an_unforced_review(self):
+        args = self._dispatch("pull_request", {
+            "action": "opened",
+            "pull_request": {
+                "draft": False,
+                "user": {"type": "User"},
+                "html_url": "https://github.com/o/r/pull/1",
+            },
+        })
+        assert args is not None, "no review was dispatched"
+        assert args[4] is False, "an ordinary PR event must not be forced"


### PR DESCRIPTION
Closes #49
Closes #48

Landed together, as both issues asked. They are one defect with two halves: #49 is the trigger, #48 is the action, and each is inert without the other — dismissal logic that only runs on a re-review is unreachable while re-review itself is gated on new commits.

## Summary

A PR could reach `REVIEW_REQUIRED` with 0 unresolved threads and green CI, and no Vigil path could clear it. Observed twice for real: F2iLLC/bioqms-core#1472 (block left **outstanding** at head, and factually wrong per bioqms-core#1474) and F2iLLC/praxislms#263 (block **dismissed** at head; sat ~3h until a human approved).

The two remedies available before this change were both bad — a human hand-dismissing Vigil's verdict, which defeats the control, or a no-op push to farm a re-review, which falsifies the commit record. **No no-op-push path is implemented, suggested, or documented here.**

## The gate condition, and why it is a disjunction

Re-review now runs when **any** of: `forced` (on-demand `/vigil review`) · an outstanding Vigil block exists · there is no *settled* verdict on the current head · Vigil threads were resolved during this run. "Settled" means a Vigil review **at this exact commit** in state `APPROVED` or `COMMENTED`.

Neither single condition covers both incidents, which is the trap here:

| Incident | Shape | Caught by |
| --- | --- | --- |
| bioqms-core#1472 | live `CHANGES_REQUESTED` at head | outstanding-block check (and also not-settled) |
| praxislms#263 | verdict **dismissed** at head | **not-settled only** — nothing is outstanding |

Keying only on "an outstanding CHANGES_REQUESTED exists" misses the second; keying only on "no live review at head" misses the first. The test for the dismissed-head case asserts the premise (`select_outstanding_vigil_blocks(reviews) == []`) before asserting the fix, so it cannot silently degenerate into testing the easy path.

**The ordinary short-circuit survives** — no new commits, no standing block, nobody asked → still skips. There is a dedicated cost-guard test, because a regression here would burn LLM spend fleet-wide on every PR event.

## Withdrawing a stale block (#48)

`grep -rn "dismissals" src/` returned nothing before this PR: there was no call to GitHub's review-dismissal API anywhere, and `dismiss-resolved` is a misnomer that resolves inline comment threads and never touches a verdict.

New `dismiss_stale_vigil_blocks()` dismisses prior Vigil `CHANGES_REQUESTED` reviews, naming the head SHA that satisfied them — behind **three positive guards, all of which must hold**, phrased so missing or unexpected data fails closed:

1. the replacement review posted without raising,
2. this run's verdict is `APPROVE`,
3. GitHub accepted it as `event=APPROVE`, **not** a degraded `COMMENT` or issue-comment fallback.

Guard 3 is the important one: a COMMENT review does not clear a block, so dismissing the old one there would leave the PR **completely unguarded**. That is the worst failure mode available in this change. A `REQUEST_CHANGES` verdict deliberately changes nothing — Vigil standing its ground is correct.

## Changes

- **`src/vigil/comment_manager.py`** — `select_outstanding_vigil_blocks` / `has_settled_vigil_verdict_at` (pure), `get_vigil_review_state` (one fetch, returns SHA + state), `dismiss_stale_vigil_blocks`, and the `_dismiss_review` HTTP seam. `get_last_reviewed_sha` is **untouched** apart from a docstring note, so its other caller still works.
- **`src/vigil/github_review.py`** — optional `outcome` out-param on `post_review` recording `requested_event` / `submitted_event` as the 422 ladder degrades. Additive; no signature break.
- **`src/vigil/cli.py`** — `--force` / `--reason`, the pure `_rereview_reasons` gate, the guarded dismissal call.
- **`src/vigil/webhook.py`** — a *second* entry point serving `/vigil review` that shelled out without `--force`, so the defect survived there too. Now forwards the signal.
- **`action.yml`**, **`.github/workflows/reusable-vigil.yml`** — `force`/`reason` plumbed from the `issue_comment` trigger.
- **`README.md`**, **`tests/test_documentation_contract.py`** — the lifecycle section described the old step 3; the docs-contract allowlist is hardcoded, so new inputs would otherwise slip through silently.

## Test plan

- [x] Full suite green: `541 passed, 1 warning` (baseline on unmodified tree: `476 passed`). Independently re-run by the orchestrator, not just self-reported.
- [x] 65 new tests in `tests/test_rereview_and_dismissal.py`, following the existing mocking patterns in `test_incremental_review.py` / `test_comment_manager.py`.
- [x] Every acceptance criterion in #49, and 4 of 5 in #48 (the fifth is below).
- [x] Both real incidents covered as distinct shapes, plus the end-to-end resurrection sequence: block at A → approve at B → push C.
- [x] **17 mutations run and reverted, each confirmed to fail a test** — including the naive outstanding-blocks-only trigger (4 fail), liveness-by-recency (5 fail), dropping the degraded-event check (3 fail), dismissing on any verdict (1 fail), and removing the short-circuit (2 fail). Two mutations initially *passed* and exposed real gaps that were then fixed — one was a masked guard, the other a `raise_for_status` mock that hid an implementation raising on 403 instead of degrading. That second one was a defect in the code, not only the test.
- [ ] **NOT met, knowingly: "Self-dismissal permission verified on a scratch PR" (#48).** No live call was made to the dismissal endpoint. GitHub hides self-dismissal in the UI and whether the REST endpoint permits an identity to dismiss its own review is **unverified**. Exercising it against a real PR under the `vigil-reviewer` identity is a fleet-affecting side effect this automated pass would not take unilaterally.

## Items for reviewer attention

1. **Self-dismissal is unverified — this is the open risk.** The call is routed through an injectable seam with both branches unit-tested, and degrades safely at runtime: on a 403/422 it logs and continues, never fails the review, never retry-storms, never leaves a PR unguarded. If GitHub rejects it, blocks simply persist as they do today. The fallback #48 proposes (dismiss with `GITHUB_TOKEN` rather than `VIGIL_REVIEW_TOKEN`) is documented at `_dismiss_review` but **not implemented**, since an untested credential switch is worse than a known gap.
2. **`COMMENTED` counts as settled, on purpose.** On a repo with no `VIGIL_REVIEW_TOKEN` every Vigil review degrades to `COMMENT`; treating those as unsettled would re-review on every PR event forever. That is the line to change if you'd rather a token-less repo re-review aggressively.
3. **A standing block now re-reviews on `reopened` / `ready_for_review` with no new commits.** Bounded and intended, but it is new spend.
4. **`reusable-vigil.yml` pins `F2iLLC/vigil@0571cd6`**, which predates the `force`/`reason` inputs. Unknown composite-action inputs are a GitHub warning rather than an error, but that pin needs advancing separately. Not moved here — the merge SHA isn't knowable in advance, and tags are off-limits to this pass.

## Release note — what actually ships, and when

Consumers pin `F2iLLC/vigil@v1`, which resolves to commit `619c79e` — already behind `main`. **Merging this delivers nothing until the operator moves `v1`.** No tag was moved, recreated, or force-pushed.

One nuance worth having straight when it does ship: the **core deadlock fix needs no consumer change**. The outstanding-block and not-settled-at-head conditions are evaluated inside the CLI from the API, so both real incidents are covered by the action alone. Only the explicit `/vigil review` **force** path needs the new `force` input, and the four consumer repos each maintain their own `vigil.yml` that does not pass it yet — so that refinement stays inert for them until those workflows are updated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
